### PR TITLE
Update architecture doc references

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ src/
 
 Detailed documentation is available in the `docs/` directory:
 - [Project Context](docs/project_context.md)
-- [Architecture Guide](docs/architecture.md)
+- [Architecture Guide](docs/technical_specification.md)
 - [Product Design Specification](docs/product_design_specification.md)
 - [Technical Specification](docs/technical_specification.md)
 - [Aesthetics Guidelines](docs/aesthetics_guidelines.md)

--- a/docs/workflow_guide.md
+++ b/docs/workflow_guide.md
@@ -13,7 +13,7 @@ To ensure that all development conversations maintain the proper context and fol
    This will output the essential context from your project documentation. Copy this output and include it at the beginning of your conversation to provide the AI with necessary context.
 
 2. **Reference specific documentation** when needed:
-   - For architectural questions: refer to `docs/architecture.md`
+   - For architectural questions: refer to `docs/technical_specification.md`
    - For UI design and aesthetics: refer to `docs/aesthetics_guidelines.md`
    - For product specifications: refer to `docs/product_design_specification.md`
    - For technical implementation: refer to `docs/technical_specification.md`


### PR DESCRIPTION
## Summary
- fix broken architecture doc links by pointing to `technical_specification.md`

## Testing
- `grep -R "docs/architecture.md" -n || true`

------
https://chatgpt.com/codex/tasks/task_e_684000dd78408330908addc95c59b3e5