### PR TITLE
Update docs for strategy template generator and error logging route

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Backtester App is a tool for testing and analyzing trading strategies using hist
 - Result analysis with key metrics (CAGR, Sharpe Ratio, max drawdown)
 - Interactive visualizations (equity charts, returns heatmap, signal charts)
 - Intuitive wizard interface with visual stepper navigation
+- `StrategyTemplateGenerator` utility for creating new strategy templates
 
 ## Installation
 
@@ -35,6 +36,12 @@ python app.py
 ```
 
 The application will be available at http://127.0.0.1:8050/ in your browser.
+
+## Client-Side Error Logging
+
+Errors from the browser are sent to the `/log-client-errors` endpoint. The
+frontend JavaScript captures uncaught errors and posts them to this route so
+they can be logged by the server.
 
 ## Versioning System
 

--- a/docs/technical_specification.md
+++ b/docs/technical_specification.md
@@ -103,6 +103,10 @@ The application uses Python's built-in `logging` module with a simplified config
 - External library log suppression (e.g., werkzeug, urllib3, dash set to WARNING).
 - Log levels: DEBUG, INFO, WARNING, ERROR, CRITICAL.
 
+Client-side JavaScript errors are sent via POST requests to the
+`/log-client-errors` route. This endpoint logs received errors, warnings and
+messages on the server for easier debugging.
+
 Example log configuration from `app_factory.py`:
 ```python
 def configure_logging(log_level=logging.INFO) -> None:
@@ -143,6 +147,7 @@ def configure_logging(log_level=logging.INFO) -> None:
 ### 2.3 Developer Tools
 - **Git**: Version control
 - **SemVer**: Semantic versioning standard
+- **StrategyTemplateGenerator**: Generates boilerplate code for new strategies
 
 ## 3. Key Algorithms (Pseudocode Examples)
 


### PR DESCRIPTION
## Summary
- highlight `StrategyTemplateGenerator` as a utility for generating new strategy templates
- describe the `/log-client-errors` endpoint used to record browser errors

## Testing
- `python -m compileall -q src`

------
https://chatgpt.com/codex/tasks/task_e_684007a8e61c83309e74cf0bcc250ac9