### PR TITLE
Update docs for import modal & logging endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Backtester App is a tool for testing and analyzing trading strategies using hist
 - Result analysis with key metrics (CAGR, Sharpe Ratio, max drawdown)
 - Interactive visualizations (equity charts, returns heatmap, signal charts)
 - Intuitive wizard interface with visual stepper navigation
+- Import tickers via modal (paste text or upload file)
 
 ## Installation
 

--- a/docs/technical_specification.md
+++ b/docs/technical_specification.md
@@ -102,6 +102,7 @@ The application uses Python's built-in `logging` module with a simplified config
 - Structured log format: `%(asctime)s [%(levelname)s] %(name)s:%(lineno)d - %(message)s`.
 - External library log suppression (e.g., werkzeug, urllib3, dash set to WARNING).
 - Log levels: DEBUG, INFO, WARNING, ERROR, CRITICAL.
+- Client-side errors are posted to `/log-client-errors` for centralized logging.
 
 Example log configuration from `app_factory.py`:
 ```python


### PR DESCRIPTION
## Summary
- document Import Tickers modal in README
- mention /log-client-errors endpoint in technical spec

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684007a80228833093f559958759431d