### PR TITLE
Clarify portfolio risk check behavior

### DIFF
--- a/src/portfolio/risk_manager.py
+++ b/src/portfolio/risk_manager.py
@@ -275,12 +275,10 @@ class RiskManager:
     def check_portfolio_risk(self, current_date, portfolio):
         """
         Check if portfolio risk limits have been exceeded.
-        Returns True if portfolio risk limits are acceptable.
-        Returns False if risk limits are breached (and continue_iterate=False).
-        
-        Note: As of April 2025, this method has been modified to always return True
-        to ensure backtests only stop when the period ends or capital is depleted,
-        while still logging warnings when risk limits are breached.
+
+        This method now always returns ``True`` and only logs warnings when
+        risk thresholds are breached. Backtests are no longer interrupted if a
+        limit is exceeded.
         """
         # If no drawdown protection is enabled, just return True
         if not self._use_drawdown_protection:


### PR DESCRIPTION
## Summary
- update `RiskManager.check_portfolio_risk` docstring to clarify that the method always returns `True` and only logs warnings when limits are exceeded

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684009f1bd9c8330aabaa16da61c22ec