### PR TITLE
Add trailing stop config defaults

### DIFF
--- a/src/portfolio/risk_manager.py
+++ b/src/portfolio/risk_manager.py
@@ -33,6 +33,14 @@ class RiskManager:
         self.max_open_positions = float('inf')  # unlimited until configured
         self.stop_loss_pct = 0.0  # fraction of price for stop loss
         self.profit_target_ratio = 1.0  # risk:reward ratio for take profit
+
+        # Market trend filter & trailing stop defaults
+        self.market_trend_lookback = config.get('market_trend_lookback', 200) if config else 200
+        self.trailing_stop_activation = 0.05
+        self.trailing_stop_distance = 0.03
+
+        # Instance logger
+        self.logger = logging.getLogger(__name__)
         
         # Feature flags for risk management
         self._apply_risk_rules = False  # Only apply risk rules when checkbox is checked
@@ -69,6 +77,9 @@ class RiskManager:
         self.max_open_positions = get_numeric_config('max_open_positions', self.max_open_positions)
         self.stop_loss_pct = get_numeric_config('stop_loss_pct', self.stop_loss_pct)
         self.profit_target_ratio = get_numeric_config('profit_target_ratio', self.profit_target_ratio)
+        self.market_trend_lookback = get_numeric_config('market_trend_lookback', self.market_trend_lookback)
+        self.trailing_stop_activation = get_numeric_config('trailing_stop_activation', self.trailing_stop_activation)
+        self.trailing_stop_distance = get_numeric_config('trailing_stop_distance', self.trailing_stop_distance)
 
         # Load feature flags (booleans are generally safe with .get)
         self._apply_risk_rules = config.get('apply_risk_rules', self._apply_risk_rules)


### PR DESCRIPTION
## Summary
- initialize trend lookback and trailing stop settings in `RiskManager`
- load new config values in `_load_config`
- attach logger instance to `RiskManager`

## Testing
- `python -m py_compile src/portfolio/risk_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_684009f1e3988330ad9aa8aa1b5e72ec