### PR TITLE
Fix pandas_ta import error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
 pandas
-numpy
+# Pin numpy below 2.0 because pandas-ta currently fails to import with
+# numpy 2.x due to the removal of the NaN constant.
+numpy<2.0
 matplotlib
 yfinance
 scikit-learn


### PR DESCRIPTION
## Summary
- avoid pandas_ta failures by pinning numpy<2 in requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68400c73b19483308095011a3d87ef54