### PR TITLE
Add chart settings popovers with gear buttons

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -1032,3 +1032,16 @@ input:focus, .form-control:focus {
   height: auto !important;
   min-height: 30px !important; /* Reduced from 40px to 30px (25% reduction) */
 }
+
+/* --- Settings Popover and Gear Button Styles --- */
+.gear-btn {
+  background-color: #0d6efd !important;
+  border: none !important;
+  padding: 2px 4px !important;
+  font-size: 0.8rem !important;
+}
+
+.settings-popover-body {
+  font-size: 1rem !important;
+  font-weight: 600 !important;
+}

--- a/src/ui/callbacks/backtest_callbacks.py
+++ b/src/ui/callbacks/backtest_callbacks.py
@@ -1,29 +1,49 @@
-import dash # Added import
+import dash  # Added import
 from dash.exceptions import PreventUpdate
 import time
 import logging
 import traceback
 from datetime import datetime
 import pandas as pd
+
 # Import ALL for pattern-matching callbacks
-from dash import Dash, dcc, html, Input, Output, State, callback, no_update, ctx, ClientsideFunction, ALL
+from dash import (
+    Dash,
+    dcc,
+    html,
+    Input,
+    Output,
+    State,
+    callback,
+    no_update,
+    ctx,
+    ClientsideFunction,
+    ALL,
+)
 import plotly.graph_objects as go
 import plotly.io as pio
-import dash_bootstrap_components as dbc # Import dbc
-from dash import dash_table # Import dash_table
+import dash_bootstrap_components as dbc  # Import dbc
+from dash import dash_table  # Import dash_table
 
 # Import services and components
 from src.services.backtest_service import BacktestService
-from src.ui.components import create_metric_card 
+from src.ui.components import create_metric_card
+
 # Import layout functions needed for the new callback
 from src.visualization.chart_utils import create_empty_chart
+
 # Corrected import: Use BacktestVisualizer instead of Visualizer
 from src.visualization.visualizer import BacktestVisualizer
 from src.core.exceptions import BacktestError, DataError
 from src.core.constants import CHART_THEME
 
 # Import centralized IDs
-from src.ui.ids.ids import ResultsIDs, WizardIDs, StrategyConfigIDs, SharedComponentIDs # MODIFIED
+from src.ui.ids.ids import (
+    ResultsIDs,
+    WizardIDs,
+    StrategyConfigIDs,
+    SharedComponentIDs,
+)  # MODIFIED
 
 # Configure logging
 logger = logging.getLogger(__name__)
@@ -31,6 +51,7 @@ logger = logging.getLogger(__name__)
 # Initialize services (assuming a singleton or shared instance mechanism if needed)
 # In a real Dash app, this might be handled differently (e.g., global variable, app context)
 backtest_service = BacktestService()
+
 
 def register_backtest_callbacks(app: Dash):
     """Register callbacks related to running backtests and displaying results."""
@@ -40,75 +61,131 @@ def register_backtest_callbacks(app: Dash):
     # --- Run Backtest Callback ---
     # This callback now outputs to the store instead of directly to result components
     @app.callback(
-        Output(ResultsIDs.BACKTEST_RESULTS_STORE, 'data'),
-        Output(SharedComponentIDs.LOADING_OVERLAY, 'style'), 
-        Output(ResultsIDs.BACKTEST_PROGRESS_BAR, 'value'),
-        Output(ResultsIDs.BACKTEST_PROGRESS_LABEL_TEXT, 'children'), 
-        Output(ResultsIDs.BACKTEST_ANIMATED_TEXT, 'children'),
-        Output(ResultsIDs.BACKTEST_ANIMATION_INTERVAL, 'disabled'), 
+        Output(ResultsIDs.BACKTEST_RESULTS_STORE, "data"),
+        Output(SharedComponentIDs.LOADING_OVERLAY, "style"),
+        Output(ResultsIDs.BACKTEST_PROGRESS_BAR, "value"),
+        Output(ResultsIDs.BACKTEST_PROGRESS_LABEL_TEXT, "children"),
+        Output(ResultsIDs.BACKTEST_ANIMATED_TEXT, "children"),
+        Output(ResultsIDs.BACKTEST_ANIMATION_INTERVAL, "disabled"),
         Output(WizardIDs.PROGRESS_BAR, "style", allow_duplicate=True),
-        Output(ResultsIDs.CENTER_PANEL_COLUMN, 'style'),
-        Output(ResultsIDs.RIGHT_PANEL_COLUMN, 'style'),
-        Output(ResultsIDs.RESULTS_AREA_WRAPPER, 'style'),
-        Output(ResultsIDs.BACKTEST_PROGRESS_BAR_CONTAINER, 'is_open'),
-        Input(SharedComponentIDs.RUN_BACKTEST_TRIGGER_STORE, 'data'),
-        State(StrategyConfigIDs.STRATEGY_CONFIG_STORE_MAIN, 'data'),
+        Output(ResultsIDs.CENTER_PANEL_COLUMN, "style"),
+        Output(ResultsIDs.RIGHT_PANEL_COLUMN, "style"),
+        Output(ResultsIDs.RESULTS_AREA_WRAPPER, "style"),
+        Output(ResultsIDs.BACKTEST_PROGRESS_BAR_CONTAINER, "is_open"),
+        Input(SharedComponentIDs.RUN_BACKTEST_TRIGGER_STORE, "data"),
+        State(StrategyConfigIDs.STRATEGY_CONFIG_STORE_MAIN, "data"),
         background=True,
         running=[
-            (Output(StrategyConfigIDs.RUN_BACKTEST_BUTTON_MAIN, 'disabled'), True, False),
-            (Output(WizardIDs.RUN_BACKTEST_BUTTON_WIZARD, 'disabled'), True, False),            (Output(SharedComponentIDs.LOADING_OVERLAY, 'style'), 
-             # When running, show overlay with fixed position covering whole viewport
-             {"display": "flex", "position": "fixed", "top": "0", "left": "0", "right": "0", "bottom": "0", 
-              "backgroundColor": "rgba(18, 18, 18, 0.98)", "zIndex": "1050", 
-              "flexDirection": "column", "alignItems": "center", "justifyContent": "center"},
-             # When not running, hide overlay
-             {"display": "none"}),
-            (Output(ResultsIDs.BACKTEST_STATUS_MESSAGE, 'children'), "", ""),
-            (Output(ResultsIDs.BACKTEST_ANIMATED_TEXT, 'children'), "Running backtest... (0%)", ""),
-            (Output(ResultsIDs.BACKTEST_PROGRESS_LABEL_TEXT, 'children'), "Initializing...", " "),
-            (Output(ResultsIDs.BACKTEST_ANIMATION_INTERVAL, 'disabled'), False, True),
-            (Output(ResultsIDs.BACKTEST_PROGRESS_BAR_CONTAINER, 'is_open'), True, False),
-            (Output(WizardIDs.PROGRESS_BAR, "style"), {'display': 'none'}, no_update), 
+            (
+                Output(StrategyConfigIDs.RUN_BACKTEST_BUTTON_MAIN, "disabled"),
+                True,
+                False,
+            ),
+            (Output(WizardIDs.RUN_BACKTEST_BUTTON_WIZARD, "disabled"), True, False),
+            (
+                Output(SharedComponentIDs.LOADING_OVERLAY, "style"),
+                # When running, show overlay with fixed position covering whole viewport
+                {
+                    "display": "flex",
+                    "position": "fixed",
+                    "top": "0",
+                    "left": "0",
+                    "right": "0",
+                    "bottom": "0",
+                    "backgroundColor": "rgba(18, 18, 18, 0.98)",
+                    "zIndex": "1050",
+                    "flexDirection": "column",
+                    "alignItems": "center",
+                    "justifyContent": "center",
+                },
+                # When not running, hide overlay
+                {"display": "none"},
+            ),
+            (Output(ResultsIDs.BACKTEST_STATUS_MESSAGE, "children"), "", ""),
+            (
+                Output(ResultsIDs.BACKTEST_ANIMATED_TEXT, "children"),
+                "Running backtest... (0%)",
+                "",
+            ),
+            (
+                Output(ResultsIDs.BACKTEST_PROGRESS_LABEL_TEXT, "children"),
+                "Initializing...",
+                " ",
+            ),
+            (Output(ResultsIDs.BACKTEST_ANIMATION_INTERVAL, "disabled"), False, True),
+            (
+                Output(ResultsIDs.BACKTEST_PROGRESS_BAR_CONTAINER, "is_open"),
+                True,
+                False,
+            ),
+            (Output(WizardIDs.PROGRESS_BAR, "style"), {"display": "none"}, no_update),
             # Both panels should be hidden during backtest and initially
-            (Output(ResultsIDs.CENTER_PANEL_COLUMN, 'style'),
-             {'display': 'none'}, # Style when RUNNING
-             {'display': 'none'}), # Style when NOT RUNNING (initial)
-            (Output(ResultsIDs.RIGHT_PANEL_COLUMN, 'style'),
-             {'display': 'none'}, # Style when RUNNING
-             {'display': 'none'}), # Style when NOT RUNNING (initial)
-            (Output(ResultsIDs.RESULTS_AREA_WRAPPER, 'style'), 
-             {'display': 'none'}, # Style when RUNNING
-             {'display': 'none'}) # Style when NOT RUNNING (initial)
+            (
+                Output(ResultsIDs.CENTER_PANEL_COLUMN, "style"),
+                {"display": "none"},  # Style when RUNNING
+                {"display": "none"},
+            ),  # Style when NOT RUNNING (initial)
+            (
+                Output(ResultsIDs.RIGHT_PANEL_COLUMN, "style"),
+                {"display": "none"},  # Style when RUNNING
+                {"display": "none"},
+            ),  # Style when NOT RUNNING (initial)
+            (
+                Output(ResultsIDs.RESULTS_AREA_WRAPPER, "style"),
+                {"display": "none"},  # Style when RUNNING
+                {"display": "none"},
+            ),  # Style when NOT RUNNING (initial)
         ],
         progress=[
-            Output(ResultsIDs.BACKTEST_PROGRESS_BAR, 'value'),
-            Output(ResultsIDs.BACKTEST_PROGRESS_LABEL_TEXT, 'children')
+            Output(ResultsIDs.BACKTEST_PROGRESS_BAR, "value"),
+            Output(ResultsIDs.BACKTEST_PROGRESS_LABEL_TEXT, "children"),
         ],
-        prevent_initial_call=True
+        prevent_initial_call=True,
     )
     def run_backtest(set_progress, trigger_data, config_data):
-        def wrapped_set_progress(progress_tuple): # progress_tuple is (value, detail_message)
+        def wrapped_set_progress(
+            progress_tuple,
+        ):  # progress_tuple is (value, detail_message)
             value, detail_message = progress_tuple
-            set_progress((value, detail_message)) # Update bar value and inner detail message
+            set_progress(
+                (value, detail_message)
+            )  # Update bar value and inner detail message
 
             # Standard delays, adjust if necessary
-            if value <= 4: time.sleep(0.01)
-            elif value < 26: time.sleep(0.05)
-            else: time.sleep(0.05)
+            if value <= 4:
+                time.sleep(0.01)
+            elif value < 26:
+                time.sleep(0.05)
+            else:
+                time.sleep(0.05)
 
         logger.info("--- run_backtest callback: Entered.")
         if not trigger_data:
             logger.warning("run_backtest triggered without trigger_data.")
             raise PreventUpdate
 
-        initial_animated_text = "Running backtest... (0%)" # Set by 'running' state, but good to have a default
+        initial_animated_text = "Running backtest... (0%)"  # Set by 'running' state, but good to have a default
 
         if not config_data:
             logger.warning("run_backtest triggered without config_data.")
             # value, inner_message, outer_message, interval_disabled
-            return {"timestamp": time.time(), "success": False, "error": "Configuration data is missing."}, \
-                   {"display": "none"}, 100, "Config Error", "Config Error (100%)", True, \
-                   {'display': 'none'}, {'display': 'none'}, {'display': 'none'}, {'display': 'none'}, False
+            return (
+                {
+                    "timestamp": time.time(),
+                    "success": False,
+                    "error": "Configuration data is missing.",
+                },
+                {"display": "none"},
+                100,
+                "Config Error",
+                "Config Error (100%)",
+                True,
+                {"display": "none"},
+                {"display": "none"},
+                {"display": "none"},
+                {"display": "none"},
+                False,
+            )
 
         logger.info(f"run_backtest: Received config_data: {config_data}")
         # ... (extract parameters as before) ...
@@ -123,43 +200,86 @@ def register_backtest_callbacks(app: Dash):
         rebalancing_params_config = config_data.get("rebalancing", {})
 
         cost_params_dict = {
-            'commission_per_trade': trading_costs_config.get('commission_bps'),
-            'slippage_per_trade': trading_costs_config.get('slippage_bps')
+            "commission_per_trade": trading_costs_config.get("commission_bps"),
+            "slippage_per_trade": trading_costs_config.get("slippage_bps"),
         }
         rebalancing_params_dict = {
-            'frequency': rebalancing_params_config.get('frequency'),
-            'threshold': rebalancing_params_config.get('threshold_pct')
+            "frequency": rebalancing_params_config.get("frequency"),
+            "threshold": rebalancing_params_config.get("threshold_pct"),
         }
 
         if isinstance(tickers, list) and tickers:
             tickers_list = [str(t).strip() for t in tickers if t]
         elif isinstance(tickers, str) and tickers.strip():
-             tickers_list = [t.strip() for t in tickers.split(',') if t.strip()]
+            tickers_list = [t.strip() for t in tickers.split(",") if t.strip()]
         else:
             tickers_list = []
 
-        if not all([strategy_type, tickers_list, start_date_str, end_date_str, initial_capital is not None]):
+        if not all(
+            [
+                strategy_type,
+                tickers_list,
+                start_date_str,
+                end_date_str,
+                initial_capital is not None,
+            ]
+        ):
             error_msg = "Missing required inputs."
             logger.error(f"run_backtest: Input validation failed: {error_msg}")
-            return {"timestamp": time.time(), "success": False, "error": error_msg}, \
-                   {"display": "none"}, 100, "Input Error", "Input Error (100%)", True, \
-                   {'display': 'none'}, {'display': 'none'}, {'display': 'none'}, {'display': 'none'}, False
+            return (
+                {"timestamp": time.time(), "success": False, "error": error_msg},
+                {"display": "none"},
+                100,
+                "Input Error",
+                "Input Error (100%)",
+                True,
+                {"display": "none"},
+                {"display": "none"},
+                {"display": "none"},
+                {"display": "none"},
+                False,
+            )
         try:
-            start_date_dt = datetime.strptime(start_date_str, '%Y-%m-%d').date() if start_date_str else None
-            end_date_dt = datetime.strptime(end_date_str, '%Y-%m-%d').date() if end_date_str else None
+            start_date_dt = (
+                datetime.strptime(start_date_str, "%Y-%m-%d").date()
+                if start_date_str
+                else None
+            )
+            end_date_dt = (
+                datetime.strptime(end_date_str, "%Y-%m-%d").date()
+                if end_date_str
+                else None
+            )
         except ValueError as e:
             error_msg = f"Invalid date format: {e}."
             logger.error(f"run_backtest: {error_msg}")
-            return {"timestamp": time.time(), "success": False, "error": error_msg}, \
-                   {"display": "none"}, 100, "Date Error", "Date Error (100%)", True, \
-                   {'display': 'none'}, {'display': 'none'}, {'display': 'none'}, {'display': 'none'}, False
+            return (
+                {"timestamp": time.time(), "success": False, "error": error_msg},
+                {"display": "none"},
+                100,
+                "Date Error",
+                "Date Error (100%)",
+                True,
+                {"display": "none"},
+                {"display": "none"},
+                {"display": "none"},
+                {"display": "none"},
+                False,
+            )
 
-        if 'features' in risk_params_dict and 'enabled_features' not in risk_params_dict:
-            risk_params_dict['enabled_features'] = risk_params_dict.pop('features')
+        if (
+            "features" in risk_params_dict
+            and "enabled_features" not in risk_params_dict
+        ):
+            risk_params_dict["enabled_features"] = risk_params_dict.pop("features")
 
         try:
-            logger.info("run_backtest: Setting initial progress (1% for inner message).")
-            wrapped_set_progress((1, "Initializing Backtest...")) # value, inner_message
+            logger.info(
+                "run_backtest: Setting initial progress (1% for inner message)."
+            )
+            wrapped_set_progress(
+                (1, "Initializing Backtest...")
+            )  # value, inner_message
 
             logger.info("run_backtest: Calling backtest_service.run_backtest.")
             start_time = time.time()
@@ -174,10 +294,12 @@ def register_backtest_callbacks(app: Dash):
                 risk_params=risk_params_dict,
                 cost_params=cost_params_dict,
                 rebalancing_params=rebalancing_params_dict,
-                progress_callback=wrapped_set_progress
+                progress_callback=wrapped_set_progress,
             )
             end_time = time.time()
-            logger.info(f"run_backtest: backtest_service.run_backtest finished in {end_time - start_time:.2f} seconds.")
+            logger.info(
+                f"run_backtest: backtest_service.run_backtest finished in {end_time - start_time:.2f} seconds."
+            )
             results_package["timestamp"] = time.time()
 
             if results_package.get("success"):
@@ -185,218 +307,543 @@ def register_backtest_callbacks(app: Dash):
                 wrapped_set_progress((100, "Complete"))
                 time.sleep(0.05)
                 logger.info("run_backtest: Exiting successfully.")
-                return results_package, {"display": "none"}, 100, "Complete", "Complete (100%)", True, \
-                       no_update, {'display': 'none'}, {'display': 'none'}, {'display': 'none'}, False # Keep panels hidden until update_results_display shows them
+                return (
+                    results_package,
+                    {"display": "none"},
+                    100,
+                    "Complete",
+                    "Complete (100%)",
+                    True,
+                    no_update,
+                    {"display": "none"},
+                    {"display": "none"},
+                    {"display": "none"},
+                    False,
+                )  # Keep panels hidden until update_results_display shows them
             else:
-                error_msg = results_package.get('error', 'Unknown backtest failure')
+                error_msg = results_package.get("error", "Unknown backtest failure")
                 logger.error(f"run_backtest: Returning FAILED results: {error_msg}")
-                display_error_msg = (error_msg[:30] + '...') if len(error_msg) > 33 else error_msg
-                outer_display_error_msg = (error_msg[:40] + '...') if len(error_msg) > 43 else error_msg
+                display_error_msg = (
+                    (error_msg[:30] + "...") if len(error_msg) > 33 else error_msg
+                )
+                outer_display_error_msg = (
+                    (error_msg[:40] + "...") if len(error_msg) > 43 else error_msg
+                )
                 wrapped_set_progress((100, f"Failed: {display_error_msg}"))
                 time.sleep(0.05)
-                return results_package, {"display": "none"}, 100, f"Failed: {display_error_msg}", f"Failed: {outer_display_error_msg} (100%)", True, \
-                       no_update, {'display': 'none'}, {'display': 'none'}, {'display': 'none'}, False # Ensure panels stay hidden on failure
+                return (
+                    results_package,
+                    {"display": "none"},
+                    100,
+                    f"Failed: {display_error_msg}",
+                    f"Failed: {outer_display_error_msg} (100%)",
+                    True,
+                    no_update,
+                    {"display": "none"},
+                    {"display": "none"},
+                    {"display": "none"},
+                    False,
+                )  # Ensure panels stay hidden on failure
 
         except Exception as e:
             tb_str = traceback.format_exc()
-            logger.error(f"run_backtest: An unexpected error occurred: {e}\nTraceback:\n{tb_str}")
+            logger.error(
+                f"run_backtest: An unexpected error occurred: {e}\nTraceback:\n{tb_str}"
+            )
             error_msg = f"Unexpected error: {str(e)}"
-            display_error_msg = (error_msg[:30] + '...') if len(error_msg) > 33 else error_msg
-            outer_display_error_msg = (error_msg[:40] + '...') if len(error_msg) > 43 else error_msg
+            display_error_msg = (
+                (error_msg[:30] + "...") if len(error_msg) > 33 else error_msg
+            )
+            outer_display_error_msg = (
+                (error_msg[:40] + "...") if len(error_msg) > 43 else error_msg
+            )
             wrapped_set_progress((100, f"Error: {display_error_msg}"))
             time.sleep(0.05)
-            return {"timestamp": time.time(), "success": False, "error": error_msg}, \
-                   {"display": "none"}, 100, f"Error: {display_error_msg}", f"Error: {outer_display_error_msg} (100%)", True, \
-                   no_update, {'display': 'none'}, {'display': 'none'}, {'display': 'none'}, False # Ensure panels stay hidden on error
+            return (
+                {"timestamp": time.time(), "success": False, "error": error_msg},
+                {"display": "none"},
+                100,
+                f"Error: {display_error_msg}",
+                f"Error: {outer_display_error_msg} (100%)",
+                True,
+                no_update,
+                {"display": "none"},
+                {"display": "none"},
+                {"display": "none"},
+                False,
+            )  # Ensure panels stay hidden on error
 
     # --- NEW Animation Callback ---
     @app.callback(
-        Output(ResultsIDs.BACKTEST_ANIMATED_TEXT, 'children', allow_duplicate=True),
-        Input(ResultsIDs.BACKTEST_ANIMATION_INTERVAL, 'n_intervals'),
-        State(ResultsIDs.BACKTEST_PROGRESS_BAR, 'value'),
-        State(ResultsIDs.BACKTEST_ANIMATION_INTERVAL, 'disabled'),
-        prevent_initial_call=True
+        Output(ResultsIDs.BACKTEST_ANIMATED_TEXT, "children", allow_duplicate=True),
+        Input(ResultsIDs.BACKTEST_ANIMATION_INTERVAL, "n_intervals"),
+        State(ResultsIDs.BACKTEST_PROGRESS_BAR, "value"),
+        State(ResultsIDs.BACKTEST_ANIMATION_INTERVAL, "disabled"),
+        prevent_initial_call=True,
     )
-    def update_animated_progress_text(n_intervals, current_progress_value, interval_disabled):
-        if interval_disabled or n_intervals == 0: # Also check n_intervals to avoid update on first enable if not needed
+    def update_animated_progress_text(
+        n_intervals, current_progress_value, interval_disabled
+    ):
+        if (
+            interval_disabled or n_intervals == 0
+        ):  # Also check n_intervals to avoid update on first enable if not needed
             # When the interval is disabled (backtest not running or finished),
             # the run_backtest callback is responsible for setting the final static text.
             raise PreventUpdate
 
         # Ensure dots have consistent width using non-breaking spaces
-        dots = ['.\u00A0\u00A0', '..\u00A0', '...']  # Replaced spaces with non-breaking spaces
+        dots = [
+            ".\u00a0\u00a0",
+            "..\u00a0",
+            "...",
+        ]  # Replaced spaces with non-breaking spaces
         dot_str = dots[n_intervals % len(dots)]
-          # Ensure current_progress_value is an int for formatting
-        progress_percent = int(current_progress_value) if current_progress_value is not None else 0
-          # Return the text and a span with the percentage to utilize the CSS spacing
-        return ["Running backtest" + dot_str, html.Span(f"({progress_percent}%)", className="progress-bar-percentage")]
-    
+        # Ensure current_progress_value is an int for formatting
+        progress_percent = (
+            int(current_progress_value) if current_progress_value is not None else 0
+        )
+        # Return the text and a span with the percentage to utilize the CSS spacing
+        return [
+            "Running backtest" + dot_str,
+            html.Span(f"({progress_percent}%)", className="progress-bar-percentage"),
+        ]
+
     # --- Result Update Callbacks (Triggered by Store) ---
     @app.callback(
-        Output(ResultsIDs.PERFORMANCE_METRICS_CONTAINER, 'children'),
-        Output(ResultsIDs.TRADE_METRICS_CONTAINER, 'children'),
-        Output(ResultsIDs.TRADES_TABLE_CONTAINER, 'children'),
-        Output(ResultsIDs.PORTFOLIO_CHART, 'figure'),
-        Output(ResultsIDs.DRAWDOWN_CHART, 'figure'),
-        Output(ResultsIDs.MONTHLY_RETURNS_HEATMAP, 'figure'),
-        Output(ResultsIDs.SIGNALS_TICKER_SELECTOR, 'options'),
-        Output(ResultsIDs.SIGNALS_TICKER_SELECTOR, 'value'),
-        Output(ResultsIDs.RESULTS_AREA_WRAPPER, 'style', allow_duplicate=True),
-        Output(ResultsIDs.CENTER_PANEL_COLUMN, 'style', allow_duplicate=True),
-        Output(ResultsIDs.RIGHT_PANEL_COLUMN, 'style', allow_duplicate=True),
-        Output(ResultsIDs.PERFORMANCE_OVERVIEW_CARD, 'style'),
-        Output(ResultsIDs.TRADE_STATISTICS_CARD, 'style'),
-        Input(ResultsIDs.BACKTEST_RESULTS_STORE, 'data'),
-        prevent_initial_call=True    )
+        Output(ResultsIDs.PERFORMANCE_METRICS_CONTAINER, "children"),
+        Output(ResultsIDs.TRADE_METRICS_CONTAINER, "children"),
+        Output(ResultsIDs.TRADES_TABLE_CONTAINER, "children"),
+        Output(ResultsIDs.PORTFOLIO_CHART, "figure"),
+        Output(ResultsIDs.DRAWDOWN_CHART, "figure"),
+        Output(ResultsIDs.MONTHLY_RETURNS_HEATMAP, "figure"),
+        Output(ResultsIDs.SIGNALS_TICKER_SELECTOR, "options"),
+        Output(ResultsIDs.SIGNALS_TICKER_SELECTOR, "value"),
+        Output(ResultsIDs.RESULTS_AREA_WRAPPER, "style", allow_duplicate=True),
+        Output(ResultsIDs.CENTER_PANEL_COLUMN, "style", allow_duplicate=True),
+        Output(ResultsIDs.RIGHT_PANEL_COLUMN, "style", allow_duplicate=True),
+        Output(ResultsIDs.PERFORMANCE_OVERVIEW_CARD, "style"),
+        Output(ResultsIDs.TRADE_STATISTICS_CARD, "style"),
+        Input(ResultsIDs.BACKTEST_RESULTS_STORE, "data"),
+        prevent_initial_call=True,
+    )
     def update_results_display(results_data):
         logger.info("--- update_results_display callback triggered ---")
-        
-        if not results_data or not results_data.get('success'):
-            logger.warning("--- update_results_display: results_data indicates failure or is invalid. Returning empty/default components and hiding panels.")
+
+        if not results_data or not results_data.get("success"):
+            logger.warning(
+                "--- update_results_display: results_data indicates failure or is invalid. Returning empty/default components and hiding panels."
+            )
             empty_fig = create_empty_chart("No data available")
             # Always ensure panels are hidden when there's no valid data
-            return ([], [], html.Div("Backtest failed or no data."), 
-                    empty_fig, empty_fig, empty_fig, 
-                    [], None, {'display': 'none'}, {'display': 'none'}, {'display': 'none'}, 
-                    {'display': 'none'}, {'display': 'none'})
+            return (
+                [],
+                [],
+                html.Div("Backtest failed or no data."),
+                empty_fig,
+                empty_fig,
+                empty_fig,
+                [],
+                None,
+                {"display": "none"},
+                {"display": "none"},
+                {"display": "none"},
+                {"display": "none"},
+                {"display": "none"},
+            )
 
-        metrics = results_data.get('metrics', {})
-        trades_list = results_data.get('trades_data', [])
-        
+        metrics = results_data.get("metrics", {})
+        trades_list = results_data.get("trades_data", [])
+
         # Make sure metrics is a dictionary, not None or empty list
         if not metrics or not isinstance(metrics, dict):
-            logger.warning("--- update_results_display: No metrics available or invalid metrics format")
+            logger.warning(
+                "--- update_results_display: No metrics available or invalid metrics format"
+            )
             metrics = {}
-            
+
         # Make sure trades_list is a list, not None
         if not trades_list or not isinstance(trades_list, list):
-            logger.warning("--- update_results_display: No trades data available or invalid trades format")
+            logger.warning(
+                "--- update_results_display: No trades data available or invalid trades format"
+            )
             trades_list = []
-        
-        perf_metrics = {k: v for k, v in metrics.items() if "Trade" not in k and "Win" not in k and "Loss" not in k and "Ratio" not in k and "Avg" not in k and "Profit Factor" not in k and "Trades" not in k}
+
+        perf_metrics = {
+            k: v
+            for k, v in metrics.items()
+            if "Trade" not in k
+            and "Win" not in k
+            and "Loss" not in k
+            and "Ratio" not in k
+            and "Avg" not in k
+            and "Profit Factor" not in k
+            and "Trades" not in k
+        }
         trade_stats = {k: v for k, v in metrics.items() if k not in perf_metrics}
 
         # More robust check for meaningful data - ensure we have actual values to display
-        has_performance_metrics = bool(perf_metrics) and any(v is not None and (not isinstance(v, (int, float)) or v != 0) for v in perf_metrics.values())
-        has_trade_stats = bool(trade_stats) and any(v is not None and (not isinstance(v, (int, float)) or v != 0) for v in trade_stats.values())
-        has_trades = bool(trades_list) and len(trades_list) > 0 and isinstance(trades_list[0], dict) and bool(trades_list[0])
-        
+        has_performance_metrics = bool(perf_metrics) and any(
+            v is not None and (not isinstance(v, (int, float)) or v != 0)
+            for v in perf_metrics.values()
+        )
+        has_trade_stats = bool(trade_stats) and any(
+            v is not None and (not isinstance(v, (int, float)) or v != 0)
+            for v in trade_stats.values()
+        )
+        has_trades = (
+            bool(trades_list)
+            and len(trades_list) > 0
+            and isinstance(trades_list[0], dict)
+            and bool(trades_list[0])
+        )
+
         has_meaningful_data = has_performance_metrics or has_trade_stats or has_trades
-        
+
         if not has_meaningful_data:
-            logger.warning("--- update_results_display: Backtest successful but no meaningful data to display. Hiding panels.")
-            empty_fig = create_empty_chart("Backtest completed but no results to display")
-            return ([], [], html.Div("Backtest completed but no results to display."), 
-                    empty_fig, empty_fig, empty_fig, 
-                    [], None, {'display': 'none'}, {'display': 'none'}, {'display': 'none'},
-                    {'display': 'none'}, {'display': 'none'})
+            logger.warning(
+                "--- update_results_display: Backtest successful but no meaningful data to display. Hiding panels."
+            )
+            empty_fig = create_empty_chart(
+                "Backtest completed but no results to display"
+            )
+            return (
+                [],
+                [],
+                html.Div("Backtest completed but no results to display."),
+                empty_fig,
+                empty_fig,
+                empty_fig,
+                [],
+                None,
+                {"display": "none"},
+                {"display": "none"},
+                {"display": "none"},
+                {"display": "none"},
+                {"display": "none"},
+            )
 
         # Only create children components if we have meaningful data
-        performance_metrics_children = [
-            dbc.Col(create_metric_card(title, f"{value:.2f}" if isinstance(value, (int, float)) else str(value)), width=6, md=4, lg=3) 
-            for title, value in perf_metrics.items() if value is not None        ] if has_performance_metrics else []
-        
-        trade_metrics_children = [
-            dbc.Col(create_metric_card(title, f"{value:.2f}" if isinstance(value, (int, float)) else str(value)), width=6, md=4, lg=3)
-            for title, value in trade_stats.items() if value is not None
-        ] if has_trade_stats else []
-        
+        performance_metrics_children = (
+            [
+                dbc.Col(
+                    create_metric_card(
+                        title,
+                        (
+                            f"{value:.2f}"
+                            if isinstance(value, (int, float))
+                            else str(value)
+                        ),
+                    ),
+                    width=6,
+                    md=4,
+                    lg=3,
+                )
+                for title, value in perf_metrics.items()
+                if value is not None
+            ]
+            if has_performance_metrics
+            else []
+        )
+
+        trade_metrics_children = (
+            [
+                dbc.Col(
+                    create_metric_card(
+                        title,
+                        (
+                            f"{value:.2f}"
+                            if isinstance(value, (int, float))
+                            else str(value)
+                        ),
+                    ),
+                    width=6,
+                    md=4,
+                    lg=3,
+                )
+                for title, value in trade_stats.items()
+                if value is not None
+            ]
+            if has_trade_stats
+            else []
+        )
+
         # Create trades table only if we have valid trades data
         if has_trades:
             # Check if trade data contains the expected columns
             if trades_list and isinstance(trades_list[0], dict) and trades_list[0]:
                 trades_table_component = dash_table.DataTable(
                     data=trades_list,
-                    columns=[{'name': i, 'id': i} for i in trades_list[0].keys()],
+                    columns=[{"name": i, "id": i} for i in trades_list[0].keys()],
                     style_as_list_view=True,
-                    style_header={'backgroundColor': 'rgb(30, 30, 30)', 'color': 'white', 'fontWeight': 'bold'},
-                    style_cell={'backgroundColor': 'rgb(50, 50, 50)', 'color': 'white', 'textAlign': 'left', 'padding': '5px'},
+                    style_header={
+                        "backgroundColor": "rgb(30, 30, 30)",
+                        "color": "white",
+                        "fontWeight": "bold",
+                    },
+                    style_cell={
+                        "backgroundColor": "rgb(50, 50, 50)",
+                        "color": "white",
+                        "textAlign": "left",
+                        "padding": "5px",
+                    },
                     page_size=10,
                 )
             else:
-                trades_table_component = html.Div("No trades executed or invalid trade data format.")
+                trades_table_component = html.Div(
+                    "No trades executed or invalid trade data format."
+                )
         else:
             trades_table_component = html.Div("No trades executed during the backtest.")
 
         # Process chart figures if available, otherwise create empty placeholders
         portfolio_chart_fig = None
         try:
-            portfolio_chart_fig = pio.from_json(results_data.get('portfolio_value_chart_json')) if results_data.get('portfolio_value_chart_json') else None
+            portfolio_chart_fig = (
+                pio.from_json(results_data.get("portfolio_value_chart_json"))
+                if results_data.get("portfolio_value_chart_json")
+                else None
+            )
         except Exception as e:
             logger.error(f"Error parsing portfolio chart: {e}")
         if not portfolio_chart_fig:
-            portfolio_chart_fig = create_empty_chart("Portfolio Value data not available")
+            portfolio_chart_fig = create_empty_chart(
+                "Portfolio Value data not available"
+            )
 
         drawdown_chart_fig = None
         try:
-            drawdown_chart_fig = pio.from_json(results_data.get('drawdown_chart_json')) if results_data.get('drawdown_chart_json') else None
+            drawdown_chart_fig = (
+                pio.from_json(results_data.get("drawdown_chart_json"))
+                if results_data.get("drawdown_chart_json")
+                else None
+            )
         except Exception as e:
             logger.error(f"Error parsing drawdown chart: {e}")
         if not drawdown_chart_fig:
             drawdown_chart_fig = create_empty_chart("Drawdown data not available")
-        
+
         monthly_returns_heatmap_fig = None
         try:
-            monthly_returns_heatmap_fig = pio.from_json(results_data.get('monthly_returns_heatmap_json')) if results_data.get('monthly_returns_heatmap_json') else None
+            monthly_returns_heatmap_fig = (
+                pio.from_json(results_data.get("monthly_returns_heatmap_json"))
+                if results_data.get("monthly_returns_heatmap_json")
+                else None
+            )
         except Exception as e:
             logger.error(f"Error parsing monthly returns heatmap: {e}")
         if not monthly_returns_heatmap_fig:
-            monthly_returns_heatmap_fig = create_empty_chart("Monthly Returns data not available")
+            monthly_returns_heatmap_fig = create_empty_chart(
+                "Monthly Returns data not available"
+            )
 
         # Process ticker options
-        tickers = results_data.get('selected_tickers', [])
-        ticker_options = [{'label': t, 'value': t} for t in tickers] if tickers else []
+        tickers = results_data.get("selected_tickers", [])
+        ticker_options = [{"label": t, "value": t} for t in tickers] if tickers else []
         ticker_value = tickers[0] if tickers else None
-        
-        logger.info("--- update_results_display callback successfully processed data and is returning updates. ---")
-        
+
+        logger.info(
+            "--- update_results_display callback successfully processed data and is returning updates. ---"
+        )
+
         # Only show panels if we have meaningful data to display
         if has_meaningful_data:
             logger.info("Showing result panels - meaningful data is available")
-            return (performance_metrics_children, trade_metrics_children, trades_table_component,
-                    portfolio_chart_fig, drawdown_chart_fig, monthly_returns_heatmap_fig, 
-                    ticker_options, ticker_value, {'display': 'block'}, # RESULTS_AREA_WRAPPER
-                    {'display': 'block', 'paddingLeft': '3.75px', 'paddingRight': '3.75px'}, # CENTER_PANEL_COLUMN
-                    {'display': 'block', 'paddingLeft': '3.75px'}, # RIGHT_PANEL_COLUMN
-                    {'display': 'block'}, # PERFORMANCE_OVERVIEW_CARD
-                    {'display': 'block'}) # TRADE_STATISTICS_CARD
+            return (
+                performance_metrics_children,
+                trade_metrics_children,
+                trades_table_component,
+                portfolio_chart_fig,
+                drawdown_chart_fig,
+                monthly_returns_heatmap_fig,
+                ticker_options,
+                ticker_value,
+                {"display": "block"},  # RESULTS_AREA_WRAPPER
+                {
+                    "display": "block",
+                    "paddingLeft": "3.75px",
+                    "paddingRight": "3.75px",
+                },  # CENTER_PANEL_COLUMN
+                {"display": "block", "paddingLeft": "3.75px"},  # RIGHT_PANEL_COLUMN
+                {"display": "block"},  # PERFORMANCE_OVERVIEW_CARD
+                {"display": "block"},
+            )  # TRADE_STATISTICS_CARD
         else:
-            logger.warning("Keeping result panels hidden - no meaningful data available")
-            return ([], [], html.Div("No meaningful backtest data to display."), 
-                    create_empty_chart("No portfolio data"), create_empty_chart("No drawdown data"), create_empty_chart("No monthly returns data"), 
-                    [], None, {'display': 'none'}, {'display': 'none'}, {'display': 'none'},
-                    {'display': 'none'}, {'display': 'none'})
+            logger.warning(
+                "Keeping result panels hidden - no meaningful data available"
+            )
+            return (
+                [],
+                [],
+                html.Div("No meaningful backtest data to display."),
+                create_empty_chart("No portfolio data"),
+                create_empty_chart("No drawdown data"),
+                create_empty_chart("No monthly returns data"),
+                [],
+                None,
+                {"display": "none"},
+                {"display": "none"},
+                {"display": "none"},
+                {"display": "none"},
+                {"display": "none"},
+            )
 
     logger.info("Backtest callbacks registered.")
 
     # --- New Interactive Chart Callbacks ---
 
     @app.callback(
-        Output(ResultsIDs.PORTFOLIO_CHART, "figure", allow_duplicate=True),
-        Input(ResultsIDs.PORTFOLIO_SCALE_RADIO, "value"),
-        State(ResultsIDs.BACKTEST_RESULTS_STORE, "data"),
-        prevent_initial_call=True
+        Output(ResultsIDs.PORTFOLIO_SETTINGS_POPOVER, "is_open"),
+        Input(ResultsIDs.PORTFOLIO_SETTINGS_BUTTON, "n_clicks"),
+        State(ResultsIDs.PORTFOLIO_SETTINGS_POPOVER, "is_open"),
+        prevent_initial_call=True,
     )
-    def update_portfolio_chart_scale(scale_mode, results_data):
-        """Update portfolio chart with linear or log scale."""
-        if not results_data or not results_data.get("portfolio_value_chart_json"):
+    def toggle_portfolio_popover(n, is_open):
+        if n:
+            return not is_open
+        return is_open
+
+    @app.callback(
+        Output(ResultsIDs.DRAWDOWN_SETTINGS_POPOVER, "is_open"),
+        Input(ResultsIDs.DRAWDOWN_SETTINGS_BUTTON, "n_clicks"),
+        State(ResultsIDs.DRAWDOWN_SETTINGS_POPOVER, "is_open"),
+        prevent_initial_call=True,
+    )
+    def toggle_drawdown_popover(n, is_open):
+        if n:
+            return not is_open
+        return is_open
+
+    @app.callback(
+        Output(ResultsIDs.PORTFOLIO_CHART, "figure", allow_duplicate=True),
+        Output(ResultsIDs.PORTFOLIO_SETTINGS_STORE, "data"),
+        Output(ResultsIDs.PORTFOLIO_VALUE_CURRENCY_USD, "outline"),
+        Output(ResultsIDs.PORTFOLIO_VALUE_CURRENCY_PERCENT, "outline"),
+        Output(ResultsIDs.PORTFOLIO_SCALE_LINEAR_BTN, "outline"),
+        Output(ResultsIDs.PORTFOLIO_SCALE_LOG_BTN, "outline"),
+        Input(ResultsIDs.PORTFOLIO_VALUE_CURRENCY_USD, "n_clicks"),
+        Input(ResultsIDs.PORTFOLIO_VALUE_CURRENCY_PERCENT, "n_clicks"),
+        Input(ResultsIDs.PORTFOLIO_SCALE_LINEAR_BTN, "n_clicks"),
+        Input(ResultsIDs.PORTFOLIO_SCALE_LOG_BTN, "n_clicks"),
+        State(ResultsIDs.PORTFOLIO_SETTINGS_STORE, "data"),
+        State(ResultsIDs.BACKTEST_RESULTS_STORE, "data"),
+        prevent_initial_call=True,
+    )
+    def update_portfolio_chart(
+        usd_click, pct_click, lin_click, log_click, settings, results_data
+    ):
+        if not results_data:
             raise PreventUpdate
+        settings = settings or {"y_axis": "usd", "scale": "linear"}
+        triggered = ctx.triggered_id
+        if triggered == ResultsIDs.PORTFOLIO_VALUE_CURRENCY_USD:
+            settings["y_axis"] = "usd"
+        elif triggered == ResultsIDs.PORTFOLIO_VALUE_CURRENCY_PERCENT:
+            settings["y_axis"] = "percent"
+        elif triggered == ResultsIDs.PORTFOLIO_SCALE_LINEAR_BTN:
+            settings["scale"] = "linear"
+        elif triggered == ResultsIDs.PORTFOLIO_SCALE_LOG_BTN:
+            settings["scale"] = "log"
+
+        fig_json = (
+            results_data.get("portfolio_value_chart_json")
+            if settings["y_axis"] == "usd"
+            else results_data.get("portfolio_returns_chart_json")
+        )
+        if not fig_json:
+            return dash.no_update, settings, False, True, False, True
 
         try:
-            fig = pio.from_json(results_data["portfolio_value_chart_json"])
+            fig = pio.from_json(fig_json)
         except Exception as e:
             logger.error(f"Error decoding portfolio chart json: {e}")
             raise PreventUpdate
 
-        yaxis_type = "log" if scale_mode == "log" else "linear"
-        fig.update_yaxes(type=yaxis_type)
-        return fig
+        fig.update_yaxes(type="log" if settings["scale"] == "log" else "linear")
+        if settings["y_axis"] == "percent":
+            fig.update_yaxes(ticksuffix="%", tickprefix=None)
+        else:
+            fig.update_yaxes(tickprefix="$", tickformat=",.0f")
+
+        return (
+            fig,
+            settings,
+            settings["y_axis"] != "usd",
+            settings["y_axis"] != "percent",
+            settings["scale"] != "linear",
+            settings["scale"] != "log",
+        )
+
+    @app.callback(
+        Output(ResultsIDs.DRAWDOWN_CHART, "figure", allow_duplicate=True),
+        Output(ResultsIDs.DRAWDOWN_SETTINGS_STORE, "data"),
+        Output(ResultsIDs.DRAWDOWN_YAXIS_USD_BTN, "outline"),
+        Output(ResultsIDs.DRAWDOWN_YAXIS_PERCENT_BTN, "outline"),
+        Output(ResultsIDs.DRAWDOWN_SCALE_LINEAR_BTN, "outline"),
+        Output(ResultsIDs.DRAWDOWN_SCALE_LOG_BTN, "outline"),
+        Input(ResultsIDs.DRAWDOWN_YAXIS_USD_BTN, "n_clicks"),
+        Input(ResultsIDs.DRAWDOWN_YAXIS_PERCENT_BTN, "n_clicks"),
+        Input(ResultsIDs.DRAWDOWN_SCALE_LINEAR_BTN, "n_clicks"),
+        Input(ResultsIDs.DRAWDOWN_SCALE_LOG_BTN, "n_clicks"),
+        State(ResultsIDs.DRAWDOWN_SETTINGS_STORE, "data"),
+        State(ResultsIDs.BACKTEST_RESULTS_STORE, "data"),
+        prevent_initial_call=True,
+    )
+    def update_drawdown_chart(
+        usd_click, pct_click, lin_click, log_click, settings, results_data
+    ):
+        if not results_data:
+            raise PreventUpdate
+        settings = settings or {"y_axis": "percent", "scale": "linear"}
+        triggered = ctx.triggered_id
+        if triggered == ResultsIDs.DRAWDOWN_YAXIS_USD_BTN:
+            settings["y_axis"] = "usd"
+        elif triggered == ResultsIDs.DRAWDOWN_YAXIS_PERCENT_BTN:
+            settings["y_axis"] = "percent"
+        elif triggered == ResultsIDs.DRAWDOWN_SCALE_LINEAR_BTN:
+            settings["scale"] = "linear"
+        elif triggered == ResultsIDs.DRAWDOWN_SCALE_LOG_BTN:
+            settings["scale"] = "log"
+
+        fig_json = results_data.get("drawdown_chart_json")
+        if not fig_json:
+            return dash.no_update, settings, False, True, False, True
+
+        try:
+            fig = pio.from_json(fig_json)
+        except Exception as e:
+            logger.error(f"Error decoding drawdown chart json: {e}")
+            raise PreventUpdate
+
+        if settings["y_axis"] == "usd" and results_data.get(
+            "portfolio_value_chart_json"
+        ):
+            pv_fig = pio.from_json(results_data["portfolio_value_chart_json"])
+            for i, trace in enumerate(fig.data):
+                if i < len(pv_fig.data):
+                    pv = pd.Series(pv_fig.data[i].y)
+                    rolling_max = pv.cummax()
+                    dd = pv - rolling_max
+                    trace.y = dd
+            fig.update_yaxes(tickprefix="$", tickformat=",.0f")
+        else:
+            fig.update_yaxes(ticksuffix="%")
+
+        fig.update_yaxes(type="log" if settings["scale"] == "log" else "linear")
+
+        return (
+            fig,
+            settings,
+            settings["y_axis"] != "usd",
+            settings["y_axis"] != "percent",
+            settings["scale"] != "linear",
+            settings["scale"] != "log",
+        )
 
     @app.callback(
         Output(ResultsIDs.SIGNALS_CHART, "figure"),
         Input(ResultsIDs.SIGNALS_TICKER_SELECTOR, "value"),
         Input(ResultsIDs.SIGNALS_INDICATOR_CHECKLIST, "value"),
-        prevent_initial_call=True
+        prevent_initial_call=True,
     )
     def update_signals_chart(ticker, indicators):
         """Update signals chart for selected ticker with optional indicators."""

--- a/src/ui/ids/ids.py
+++ b/src/ui/ids/ids.py
@@ -4,29 +4,30 @@ This file serves as the single source of truth for all component IDs,
 preventing conflicts and making refactoring easier.
 """
 
+
 class WizardIDs:
     """IDs for components in the wizard interface."""
-    
+
     # Step 1: Initial Capital & Strategy
     INITIAL_CAPITAL_INPUT = "wizard-initial-capital-input"
     STRATEGY_DROPDOWN = "wizard-strategy-dropdown"
     STRATEGY_DESCRIPTION_OUTPUT = "wizard-strategy-description-output"
     STRATEGY_PARAM_INPUTS_CONTAINER = "wizard-strategy-param-inputs"
     CONFIRM_STRATEGY_BUTTON = "wizard-confirm-strategy"
-    
+
     # Validation IDs for real-time feedback
     # Step 1: Initial Capital and Strategy Validation
     INITIAL_CAPITAL_FEEDBACK = "wizard-initial-capital-feedback"
     STRATEGY_VALIDATION_FEEDBACK = "wizard-strategy-validation-feedback"
-    
+
     # Step 2: Date Range Validation
     DATE_START_FEEDBACK = "wizard-date-start-feedback"
     DATE_END_FEEDBACK = "wizard-date-end-feedback"
     DATE_RANGE_FEEDBACK = "wizard-date-range-feedback"
-    
+
     # Step 3: Ticker Selection Validation
     TICKER_DROPDOWN_FEEDBACK = "wizard-ticker-dropdown-feedback"
-    
+
     # Step 4: Risk Management Validation
     MAX_POSITION_SIZE_FEEDBACK = "wizard-max-position-size-feedback"
     STOP_LOSS_FEEDBACK = "wizard-stop-loss-feedback"
@@ -35,42 +36,42 @@ class WizardIDs:
     MARKET_TREND_LOOKBACK_FEEDBACK = "wizard-market-trend-lookback-feedback"
     MAX_DRAWDOWN_FEEDBACK = "wizard-max-drawdown-feedback"
     MAX_DAILY_LOSS_FEEDBACK = "wizard-max-daily-loss-feedback"
-    
+
     # Step 5: Trading Costs Validation
     COMMISSION_FEEDBACK = "wizard-commission-feedback"
     SLIPPAGE_FEEDBACK = "wizard-slippage-feedback"
-    
+
     # Step 6: Rebalancing Validation
     REBALANCING_THRESHOLD_FEEDBACK = "wizard-rebalancing-threshold-feedback"
-      # Wizard Progress & Main Containers
+    # Wizard Progress & Main Containers
     STEPS_CONTAINER = "wizard-steps-container"
     STRATEGY_CONFIG_CONTAINER = "strategy-config-container"
     WIZARD_STEPPER = "wizard-stepper"
     PROGRESS_BAR = "wizard-progress-bar"
-    PROGRESS_CONTAINER = "wizard-progress-container" # ADDED
-    
+    PROGRESS_CONTAINER = "wizard-progress-container"  # ADDED
+
     # Stepper Component IDs (NEW)
     @staticmethod
     def step_indicator(step_number):
         """Generate ID for a step indicator in the stepper."""
         return f"step-indicator-{step_number}"
-    
+
     # Step Headers and Contents (by pattern)
     @staticmethod
     def step_header(step_id):
         """Generate ID for a step header."""
         return f"{step_id}-header"
-    
+
     @staticmethod
     def step_content(step_id):
         """Generate ID for step content."""
         return f"{step_id}-content"
-    
+
     # Step 2: Date Range
     DATE_RANGE_START_PICKER = "wizard-date-start-picker"
     DATE_RANGE_END_PICKER = "wizard-date-end-picker"
     CONFIRM_DATES_BUTTON = "wizard-confirm-dates-button"
-    
+
     # Step 3: Ticker Selection
     TICKER_SELECTION_CONTAINER = "wizard-ticker-selection"
     TICKER_DROPDOWN = "wizard-ticker-dropdown"
@@ -78,18 +79,20 @@ class WizardIDs:
     CONFIRM_TICKERS_BUTTON = "wizard-confirm-tickers-button"
     SELECT_ALL_TICKERS_BUTTON = "wizard-select-all-tickers-button"
     DESELECT_ALL_TICKERS_BUTTON = "wizard-deselect-all-tickers-button"
-    
+
     # Step 4: Risk Management
     # RISK_MANAGEMENT_CONTAINER = "wizard-risk-management" # Unused
     RISK_FEATURES_CHECKLIST = "wizard-risk-features-checklist"
     MAX_POSITION_SIZE_INPUT = "wizard-max-position-size-input"
     STOP_LOSS_TYPE_SELECT = "wizard-stop-loss-type-select"
-    STOP_LOSS_INPUT = "wizard-stop-loss-input" # Existing, intended for stop loss value
+    STOP_LOSS_INPUT = "wizard-stop-loss-input"  # Existing, intended for stop loss value
     TAKE_PROFIT_TYPE_SELECT = "wizard-take-profit-type-select"
-    TAKE_PROFIT_INPUT = "wizard-take-profit-input" # Existing, intended for take profit value
+    TAKE_PROFIT_INPUT = (
+        "wizard-take-profit-input"  # Existing, intended for take profit value
+    )
     MAX_RISK_PER_TRADE_INPUT = "wizard-max-risk-per-trade-input"
     MARKET_TREND_LOOKBACK_INPUT = "wizard-market-trend-lookback-input"
-    MAX_DRAWDOWN_INPUT = "wizard-max-drawdown-input" # Existing
+    MAX_DRAWDOWN_INPUT = "wizard-max-drawdown-input"  # Existing
     MAX_DAILY_LOSS_INPUT = "wizard-max-daily-loss-input"
     CONFIRM_RISK_BUTTON = "wizard-confirm-risk-button"
 
@@ -100,38 +103,44 @@ class WizardIDs:
     RISK_PANEL_RISK_PER_TRADE = "wizard-risk-panel-risk-per-trade"
     RISK_PANEL_MARKET_FILTER = "wizard-risk-panel-market-filter"
     RISK_PANEL_DRAWDOWN_PROTECTION = "wizard-risk-panel-drawdown-protection"
-    
+
     # Step 5: Trading Costs
     # TRADING_COSTS_CONTAINER = "wizard-trading-costs" # Unused
     COMMISSION_INPUT = "wizard-commission-input"
     SLIPPAGE_INPUT = "wizard-slippage-input"
     CONFIRM_COSTS_BUTTON = "wizard-confirm-costs-button"
-    
+
     # Step 6: Rebalancing
     # REBALANCING_CONTAINER = "wizard-rebalancing" # Unused
     REBALANCING_FREQUENCY_DROPDOWN = "wizard-rebalancing-frequency"
     REBALANCING_THRESHOLD_INPUT = "wizard-rebalancing-threshold"
     CONFIRM_REBALANCING_BUTTON = "wizard-confirm-rebalancing-button"
-      # Step 7: Summary & Run
+    # Step 7: Summary & Run
     SUMMARY_CONTAINER = "wizard-summary"
     # SUMMARY_STRATEGY_NAME = "wizard-summary-strategy-name" # Unused
     # SUMMARY_INITIAL_CAPITAL = "wizard-summary-initial-capital" # Unused
     SUMMARY_OUTPUT_CONTAINER = "wizard-summary-output"
     RUN_BACKTEST_BUTTON_WIZARD = "wizard-run-backtest-button"
-    STRATEGY_PARAMS_STORE = "wizard-strategy-params-store"  # Store for strategy-specific parameters
+    STRATEGY_PARAMS_STORE = (
+        "wizard-strategy-params-store"  # Store for strategy-specific parameters
+    )
 
     # Summary Detail Fields (NEW - based on wizard_callbacks.py usage)
-    SUMMARY_STRATEGY_DETAILS = "wizard-summary-strategy" # For strategy name and initial capital
+    SUMMARY_STRATEGY_DETAILS = (
+        "wizard-summary-strategy"  # For strategy name and initial capital
+    )
     SUMMARY_DATES_DETAILS = "wizard-summary-dates"
     SUMMARY_TICKERS_DETAILS = "wizard-summary-tickers"
     SUMMARY_RISK_DETAILS = "wizard-summary-risk"
     SUMMARY_COSTS_DETAILS = "wizard-summary-costs"
     SUMMARY_REBALANCING_DETAILS = "wizard-summary-rebalancing"
-    SUMMARY_STRATEGY_PARAMETERS = "wizard-strategy-parameters-summary"    # Wizard-specific data stores
-    RISK_MANAGEMENT_STORE_WIZARD = "wizard-risk-management-store" # NEW
-    
+    SUMMARY_STRATEGY_PARAMETERS = (
+        "wizard-strategy-parameters-summary"  # Wizard-specific data stores
+    )
+    RISK_MANAGEMENT_STORE_WIZARD = "wizard-risk-management-store"  # NEW
+
     # Run Backtest Button in Wizard
-    RUN_BACKTEST_BUTTON_WIZARD = "run-backtest-button-wizard"    # Stores for wizard state
+    RUN_BACKTEST_BUTTON_WIZARD = "run-backtest-button-wizard"  # Stores for wizard state
     ACTIVE_STEP_STORE = "wizard-active-step-store"
     CONFIRMED_STEPS_STORE = "wizard-confirmed-steps-store"
     ALL_STEPS_COMPLETED_STORE = "wizard-all-steps-completed-store"
@@ -148,8 +157,8 @@ class ResultsIDs:
     PORTFOLIO_VALUE_BUTTON = "btn-chart-value"
     PORTFOLIO_RETURNS_BUTTON = "btn-chart-returns"
     # ADDED NEW IDs for currency/percentage toggle
-    PORTFOLIO_VALUE_CURRENCY_USD = "portfolio-value-currency-usd" # UNCOMMENTED
-    PORTFOLIO_VALUE_CURRENCY_PERCENT = "portfolio-value-currency-percent" # UNCOMMENTED
+    PORTFOLIO_VALUE_CURRENCY_USD = "portfolio-value-currency-usd"  # UNCOMMENTED
+    PORTFOLIO_VALUE_CURRENCY_PERCENT = "portfolio-value-currency-percent"  # UNCOMMENTED
 
     # Charts & Their Loaders
     PORTFOLIO_CHART = "portfolio-chart"
@@ -159,23 +168,38 @@ class ResultsIDs:
     DRAWDOWN_CHART_LOADING = "drawdown-chart-loading"
 
     MONTHLY_RETURNS_HEATMAP = "monthly-returns-heatmap"
-    MONTHLY_RETURNS_HEATMAP_LOADING = "heatmap-chart-loading" # as per layout
+    MONTHLY_RETURNS_HEATMAP_LOADING = "heatmap-chart-loading"  # as per layout
 
     SIGNALS_CHART = "signals-chart"
     SIGNALS_CHART_LOADING = "signals-chart-loading"
-    SIGNALS_TICKER_SELECTOR = "ticker-selector" # For signals chart
+    SIGNALS_TICKER_SELECTOR = "ticker-selector"  # For signals chart
     PORTFOLIO_SCALE_RADIO = "portfolio-scale-radio"  # Linear vs Log scale
     SIGNALS_INDICATOR_CHECKLIST = "signals-indicator-checklist"  # Indicator toggles
 
+    # Settings buttons and stores for interactive charts
+    PORTFOLIO_SETTINGS_BUTTON = "portfolio-settings-button"
+    PORTFOLIO_SETTINGS_POPOVER = "portfolio-settings-popover"
+    PORTFOLIO_SCALE_LINEAR_BTN = "portfolio-scale-linear-btn"
+    PORTFOLIO_SCALE_LOG_BTN = "portfolio-scale-log-btn"
+    PORTFOLIO_SETTINGS_STORE = "portfolio-settings-store"
+
+    DRAWDOWN_SETTINGS_BUTTON = "drawdown-settings-button"
+    DRAWDOWN_SETTINGS_POPOVER = "drawdown-settings-popover"
+    DRAWDOWN_YAXIS_USD_BTN = "drawdown-yaxis-usd-btn"
+    DRAWDOWN_YAXIS_PERCENT_BTN = "drawdown-yaxis-percent-btn"
+    DRAWDOWN_SCALE_LINEAR_BTN = "drawdown-scale-linear-btn"
+    DRAWDOWN_SCALE_LOG_BTN = "drawdown-scale-log-btn"
+    DRAWDOWN_SETTINGS_STORE = "drawdown-settings-store"
+
     # Tables & Their Loaders/Containers
-    TRADES_TABLE_CONTAINER = "trades-table-container" # UNCOMMENTED
-    TRADES_TABLE_LOADING = "trades-table-loading" # UNCOMMENTED    # Metrics Containers
-    PERFORMANCE_METRICS_CONTAINER = "performance-metrics-container" # UNCOMMENTED
-    TRADE_METRICS_CONTAINER = "trade-metrics-container" # UNCOMMENTED
-    
+    TRADES_TABLE_CONTAINER = "trades-table-container"  # UNCOMMENTED
+    TRADES_TABLE_LOADING = "trades-table-loading"  # UNCOMMENTED    # Metrics Containers
+    PERFORMANCE_METRICS_CONTAINER = "performance-metrics-container"  # UNCOMMENTED
+    TRADE_METRICS_CONTAINER = "trade-metrics-container"  # UNCOMMENTED
+
     # Cards for metrics containers
-    PERFORMANCE_OVERVIEW_CARD = "performance-overview-card" # NEW
-    TRADE_STATISTICS_CARD = "trade-statistics-card" # NEW
+    PERFORMANCE_OVERVIEW_CARD = "performance-overview-card"  # NEW
+    TRADE_STATISTICS_CARD = "trade-statistics-card"  # NEW
 
     # Status and Progress
     BACKTEST_STATUS_MESSAGE = "backtest-status"
@@ -187,55 +211,61 @@ class ResultsIDs:
     BACKTEST_ANIMATION_INTERVAL = "backtest-animation-interval"
 
     # Layout Wrappers / Areas
-    RESULTS_AREA_WRAPPER = "actual-results-area" # UNCOMMENTED
+    RESULTS_AREA_WRAPPER = "actual-results-area"  # UNCOMMENTED
 
     # These might be better in LayoutIDs if they define major page structure columns
     # For now, keeping them here as they are directly related to results visibility in callbacks
-    CENTER_PANEL_COLUMN = "center-panel-col" # UNCOMMENTED
-    RIGHT_PANEL_COLUMN = "right-panel-col" # UNCOMMENTED
+    CENTER_PANEL_COLUMN = "center-panel-col"  # UNCOMMENTED
+    RIGHT_PANEL_COLUMN = "right-panel-col"  # UNCOMMENTED
 
 
 class StrategyConfigIDs:
     """IDs for strategy configuration components outside the wizard (main page)."""
-    
+
     CONFIG_CONTAINER = "strategy-config-container-main"
-    STRATEGY_SELECTOR = "strategy-selector-main" # Main strategy dropdown
-    PARAMS_CONTAINER = "strategy-params-container-main" # Main strategy parameters container
-    
+    STRATEGY_SELECTOR = "strategy-selector-main"  # Main strategy dropdown
+    PARAMS_CONTAINER = (
+        "strategy-params-container-main"  # Main strategy parameters container
+    )
+
     # Basic Config
     INITIAL_CAPITAL_INPUT_MAIN = "initial-capital-input-main"
     TICKER_INPUT_MAIN = "ticker-input-main"
     START_DATE_PICKER_MAIN = "backtest-start-date-main"
     END_DATE_PICKER_MAIN = "backtest-end-date-main"
-    
+
     # Run Button
     RUN_BACKTEST_BUTTON_MAIN = "run-backtest-button-main"
-    
+
     # Risk Management (Main Page)
     RISK_FEATURES_CHECKLIST_MAIN = "risk-features-checklist-main"
     MAX_POSITION_SIZE_INPUT_MAIN = "max-position-size-main"
     STOP_LOSS_TYPE_SELECT_MAIN = "stop-loss-type-main"
-    STOP_LOSS_INPUT_MAIN = "stop-loss-value-main" # Input for stop loss value
+    STOP_LOSS_INPUT_MAIN = "stop-loss-value-main"  # Input for stop loss value
     TAKE_PROFIT_TYPE_SELECT_MAIN = "take-profit-type-main"
-    TAKE_PROFIT_INPUT_MAIN = "take-profit-value-main" # Input for take profit value
+    TAKE_PROFIT_INPUT_MAIN = "take-profit-value-main"  # Input for take profit value
     MAX_RISK_PER_TRADE_INPUT_MAIN = "max-risk-per-trade-main"
     MARKET_TREND_LOOKBACK_INPUT_MAIN = "market-trend-lookback-main"
     MAX_DRAWDOWN_INPUT_MAIN = "max-drawdown-main"
     MAX_DAILY_LOSS_INPUT_MAIN = "max-daily-loss-main"
-    
+
     # Trading Costs (Main Page)
     COMMISSION_INPUT_MAIN = "commission-input-main"
     SLIPPAGE_INPUT_MAIN = "slippage-input-main"
-    
+
     # Rebalancing (Main Page)
     REBALANCING_FREQUENCY_DROPDOWN_MAIN = "rebalancing-frequency-main"
     REBALANCING_THRESHOLD_INPUT_MAIN = "rebalancing-threshold-main"
 
     # Store for configuration if used by main page components
-    STRATEGY_CONFIG_STORE_MAIN = "strategy-config-store-main" # Distinct from wizard's potential store
+    STRATEGY_CONFIG_STORE_MAIN = (
+        "strategy-config-store-main"  # Distinct from wizard's potential store
+    )
 
     # IDs from src/ui/layouts/risk_management.py, potentially for a non-wizard main page context
-    RISK_FEATURES_CHECKLIST_ALT = "risk-features-checklist" # WizardIDs.RISK_FEATURES_CHECKLIST exists
+    RISK_FEATURES_CHECKLIST_ALT = (
+        "risk-features-checklist"  # WizardIDs.RISK_FEATURES_CHECKLIST exists
+    )
     POSITION_SIZING_PANEL_ALT = "position_sizing-panel"
     STOP_LOSS_PANEL_ALT = "stop_loss-panel"
     TAKE_PROFIT_PANEL_ALT = "take_profit-panel"
@@ -251,29 +281,40 @@ class StrategyConfigIDs:
     DRAWDOWN_PROTECTION_CHECKBOX_ALT = "drawdown_protection-checkbox"
     CONTINUE_ITERATE_CHECKBOX_ALT = "continue-iterate-checkbox"
 
-    RISK_MANAGEMENT_STORE_ALT = "risk-management-store" # WizardIDs.RISK_MANAGEMENT_STORE_WIZARD exists
+    RISK_MANAGEMENT_STORE_ALT = (
+        "risk-management-store"  # WizardIDs.RISK_MANAGEMENT_STORE_WIZARD exists
+    )
 
     # Inputs from src/ui/layouts/risk_management.py (alternative context)
-    MAX_POSITION_SIZE_ALT = "max-position-size" # WizardIDs.MAX_POSITION_SIZE_INPUT exists
+    MAX_POSITION_SIZE_ALT = (
+        "max-position-size"  # WizardIDs.MAX_POSITION_SIZE_INPUT exists
+    )
     MAX_PORTFOLIO_RISK_ALT = "max-portfolio-risk"
-    STOP_LOSS_TYPE_ALT = "stop-loss-type" # WizardIDs.STOP_LOSS_TYPE_SELECT exists
-    STOP_LOSS_VALUE_ALT = "stop-loss-value" # WizardIDs.STOP_LOSS_INPUT exists
-    TAKE_PROFIT_TYPE_ALT = "take-profit-type" # WizardIDs.TAKE_PROFIT_TYPE_SELECT exists
-    TAKE_PROFIT_VALUE_ALT = "take-profit-value" # WizardIDs.TAKE_PROFIT_INPUT exists
-    MAX_RISK_PER_TRADE_ALT = "max-risk-per-trade" # WizardIDs.MAX_RISK_PER_TRADE_INPUT exists
+    STOP_LOSS_TYPE_ALT = "stop-loss-type"  # WizardIDs.STOP_LOSS_TYPE_SELECT exists
+    STOP_LOSS_VALUE_ALT = "stop-loss-value"  # WizardIDs.STOP_LOSS_INPUT exists
+    TAKE_PROFIT_TYPE_ALT = (
+        "take-profit-type"  # WizardIDs.TAKE_PROFIT_TYPE_SELECT exists
+    )
+    TAKE_PROFIT_VALUE_ALT = "take-profit-value"  # WizardIDs.TAKE_PROFIT_INPUT exists
+    MAX_RISK_PER_TRADE_ALT = (
+        "max-risk-per-trade"  # WizardIDs.MAX_RISK_PER_TRADE_INPUT exists
+    )
     RISK_REWARD_RATIO_ALT = "risk-reward-ratio"
-    MARKET_TREND_LOOKBACK_ALT = "market-trend-lookback" # WizardIDs.MARKET_TREND_LOOKBACK_INPUT exists
-    MAX_DRAWDOWN_ALT = "max-drawdown" # WizardIDs.MAX_DRAWDOWN_INPUT exists
-    MAX_DAILY_LOSS_ALT = "max-daily-loss" # WizardIDs.MAX_DAILY_LOSS_INPUT exists
+    MARKET_TREND_LOOKBACK_ALT = (
+        "market-trend-lookback"  # WizardIDs.MARKET_TREND_LOOKBACK_INPUT exists
+    )
+    MAX_DRAWDOWN_ALT = "max-drawdown"  # WizardIDs.MAX_DRAWDOWN_INPUT exists
+    MAX_DAILY_LOSS_ALT = "max-daily-loss"  # WizardIDs.MAX_DAILY_LOSS_INPUT exists
 
     # IDs from src/ui/layouts/strategy_config.py (non-wizard parts, e.g. old main page elements)
-    TICKER_INPUT_LEGACY = "ticker-input" # WizardIDs.TICKER_DROPDOWN and StrategyConfigIDs.TICKER_INPUT_MAIN exist
-    BACKTEST_START_DATE_LEGACY = "backtest-start-date" # WizardIDs.DATE_RANGE_START_PICKER and StrategyConfigIDs.START_DATE_PICKER_MAIN exist
-    BACKTEST_END_DATE_LEGACY = "backtest-end-date" # WizardIDs.DATE_RANGE_END_PICKER and StrategyConfigIDs.END_DATE_PICKER_MAIN exist
+    TICKER_INPUT_LEGACY = "ticker-input"  # WizardIDs.TICKER_DROPDOWN and StrategyConfigIDs.TICKER_INPUT_MAIN exist
+    BACKTEST_START_DATE_LEGACY = "backtest-start-date"  # WizardIDs.DATE_RANGE_START_PICKER and StrategyConfigIDs.START_DATE_PICKER_MAIN exist
+    BACKTEST_END_DATE_LEGACY = "backtest-end-date"  # WizardIDs.DATE_RANGE_END_PICKER and StrategyConfigIDs.END_DATE_PICKER_MAIN exist
 
 
 class SharedComponentIDs:
     """IDs for components shared or used across different UI modules."""
+
     LOADING_OVERLAY = "loading-overlay"
     RUN_BACKTEST_TRIGGER_STORE = "run-backtest-trigger-store"
     STATUS_AND_PROGRESS_BAR_DIV = "status-and-progress-bar-div"
@@ -281,6 +322,7 @@ class SharedComponentIDs:
 
 class AppStructureIDs:
     """IDs for main application structural elements, modals, and global stores."""
+
     APP_STATE_STORE = "app-state"
 
     # Main layout columns

--- a/src/ui/layouts/results_display.py
+++ b/src/ui/layouts/results_display.py
@@ -2,6 +2,7 @@ import dash_bootstrap_components as dbc
 from dash import dcc, html
 from typing import List
 import logging
+
 # Import centralized IDs
 from src.ui import ids as app_ids
 from src.ui.ids.ids import SharedComponentIDs
@@ -10,70 +11,125 @@ logger = logging.getLogger(__name__)
 
 # Keep individual chart/table creation functions as they are used to build panels
 
+
 def create_portfolio_value_returns_chart() -> dbc.Card:
     """
-    Creates the card containing the portfolio value/returns chart and toggle buttons.    """
-    logger.debug("Creating portfolio value/returns chart card structure with Row/Col and flex-nowrap.")
-    return dbc.Card([
-        dbc.CardHeader(
-            dbc.Row(
-                [
-                    dbc.Col(
-                        html.H4("Portfolio Value", className="card-title mb-0"), 
-                        width="auto"
-                    ),
-                    dbc.Col(
-                        dbc.ButtonGroup(
+    Creates the card containing the portfolio value/returns chart and toggle buttons."""
+    logger.debug(
+        "Creating portfolio value/returns chart card structure with Row/Col and flex-nowrap."
+    )
+    return dbc.Card(
+        [
+            dbc.CardHeader(
+                dbc.Row(
+                    [
+                        dbc.Col(
+                            html.H4(
+                                "Portfolio Value",
+                                className="card-title mb-0",
+                            ),
+                            width="auto",
+                            className="d-flex align-items-center",
+                        ),
+                        dbc.Col(
+                            dbc.Button(
+                                html.I(className="fas fa-cog"),
+                                id=app_ids.ResultsIDs.PORTFOLIO_SETTINGS_BUTTON,
+                                color="primary",
+                                outline=False,
+                                size="sm",
+                                className="gear-btn",
+                            ),
+                            width="auto",
+                        ),
+                    ],
+                    align="center",  # Vertically aligns items (columns) within the Row
+                    justify="between",  # Distributes space between title (left) and buttons (right)
+                    className="gx-2 flex-nowrap",  # gx-2 for horizontal gutters, flex-nowrap to prevent wrapping
+                )
+            ),
+            dbc.Popover(
+                dbc.PopoverBody(
+                    className="settings-popover-body",
+                    [
+                        dbc.Row(
                             [
-                                dbc.Button(
-                                    "USD",
-                                    id=app_ids.ResultsIDs.PORTFOLIO_VALUE_CURRENCY_USD,
-                                    className="py-0 px-1",
-                                    color="primary",
-                                    outline=False,
-                                    size="sm",
-                                    n_clicks=0
+                                dbc.Col("Y axis in", width="auto"),
+                                dbc.Col(
+                                    dbc.Button(
+                                        "USD",
+                                        id=app_ids.ResultsIDs.PORTFOLIO_VALUE_CURRENCY_USD,
+                                        color="primary",
+                                        outline=False,
+                                        size="sm",
+                                    ),
+                                    width="auto",
                                 ),
-                                dbc.Button(
-                                    "%",
-                                    id=app_ids.ResultsIDs.PORTFOLIO_VALUE_CURRENCY_PERCENT,
-                                    className="py-0 px-1",
-                                    color="primary",
-                                    outline=True,
-                                    size="sm",
-                                    n_clicks=0
+                                dbc.Col(
+                                    dbc.Button(
+                                        "%",
+                                        id=app_ids.ResultsIDs.PORTFOLIO_VALUE_CURRENCY_PERCENT,
+                                        color="primary",
+                                        outline=True,
+                                        size="sm",
+                                    ),
+                                    width="auto",
                                 ),
                             ],
-                            size="sm"
+                            className="g-1",
                         ),
-                        width="auto"
-                    ),
-                    dbc.Col(
-                        dbc.RadioItems(
-                            id=app_ids.ResultsIDs.PORTFOLIO_SCALE_RADIO,
-                            options=[{"label": "Linear", "value": "linear"}, {"label": "Log", "value": "log"}],
-                            value="linear",
-                            inline=True,
-                            className="btn-group-sm"
+                        dbc.Row(
+                            [
+                                dbc.Col("Scale", width="auto"),
+                                dbc.Col(
+                                    dbc.Button(
+                                        "Linear",
+                                        id=app_ids.ResultsIDs.PORTFOLIO_SCALE_LINEAR_BTN,
+                                        color="primary",
+                                        outline=False,
+                                        size="sm",
+                                    ),
+                                    width="auto",
+                                ),
+                                dbc.Col(
+                                    dbc.Button(
+                                        "Log",
+                                        id=app_ids.ResultsIDs.PORTFOLIO_SCALE_LOG_BTN,
+                                        color="primary",
+                                        outline=True,
+                                        size="sm",
+                                    ),
+                                    width="auto",
+                                ),
+                            ],
+                            className="g-1 mt-1",
                         ),
-                        width="auto"
+                    ]
+                ),
+                id=app_ids.ResultsIDs.PORTFOLIO_SETTINGS_POPOVER,
+                target=app_ids.ResultsIDs.PORTFOLIO_SETTINGS_BUTTON,
+                placement="bottom-end",
+                trigger="legacy",
+                autohide=False,
+                is_open=False,
+            ),
+            dbc.CardBody(
+                [
+                    dcc.Loading(
+                        id=app_ids.ResultsIDs.PORTFOLIO_CHART_LOADING,
+                        children=[dcc.Graph(id=app_ids.ResultsIDs.PORTFOLIO_CHART)],
+                        type="circle",
                     )
-                ],
-                align="center", # Vertically aligns items (columns) within the Row
-                justify="between", # Distributes space between title (left) and buttons (right)
-                className="gx-2 flex-nowrap"  # gx-2 for horizontal gutters, flex-nowrap to prevent wrapping
-            )
-        ),
-        dbc.CardBody([
-            dcc.Loading(
-                id=app_ids.ResultsIDs.PORTFOLIO_CHART_LOADING, 
-                children=[
-                    dcc.Graph(id=app_ids.ResultsIDs.PORTFOLIO_CHART)
-                ],
-                type="circle"
-            )
-        ])
-    ], className="mb-1")
+                ]
+            ),
+            dcc.Store(
+                id=app_ids.ResultsIDs.PORTFOLIO_SETTINGS_STORE,
+                data={"y_axis": "usd", "scale": "linear"},
+            ),
+        ],
+        className="mb-1",
+    )
+
 
 def create_drawdown_chart() -> dbc.Card:
     """
@@ -81,36 +137,146 @@ def create_drawdown_chart() -> dbc.Card:
     Now uses the dedicated drawdown chart from VisualizationService.
     """
     logger.debug("Creating drawdown chart card structure.")
-    return dbc.Card([
-        dbc.CardHeader(html.H4("Drawdown (%)", className="card-title mb-0")),
-        dbc.CardBody([
-            dcc.Loading(
-                id=app_ids.ResultsIDs.DRAWDOWN_CHART_LOADING, 
-                children=dcc.Graph(
-                    id=app_ids.ResultsIDs.DRAWDOWN_CHART, # This ID will be targeted by a callback that sets the figure
+    return dbc.Card(
+        [
+            dbc.CardHeader(
+                dbc.Row(
+                    [
+                        dbc.Col(
+                            html.H4(
+                                "Drawdown",
+                                className="card-title mb-0",
+                            ),
+                            width="auto",
+                            className="d-flex align-items-center",
+                        ),
+                        dbc.Col(
+                            dbc.Button(
+                                html.I(className="fas fa-cog"),
+                                id=app_ids.ResultsIDs.DRAWDOWN_SETTINGS_BUTTON,
+                                color="primary",
+                                outline=False,
+                                size="sm",
+                                className="gear-btn",
+                            ),
+                            width="auto",
+                        ),
+                    ],
+                    justify="between",
+                    align="center",
+                    className="gx-2 flex-nowrap",
+                )
+            ),
+            dbc.Popover(
+                dbc.PopoverBody(
+                    className="settings-popover-body",
+                    [
+                        dbc.Row(
+                            [
+                                dbc.Col("Y axis in", width="auto"),
+                                dbc.Col(
+                                    dbc.Button(
+                                        "USD",
+                                        id=app_ids.ResultsIDs.DRAWDOWN_YAXIS_USD_BTN,
+                                        color="primary",
+                                        outline=True,
+                                        size="sm",
+                                    ),
+                                    width="auto",
+                                ),
+                                dbc.Col(
+                                    dbc.Button(
+                                        "%",
+                                        id=app_ids.ResultsIDs.DRAWDOWN_YAXIS_PERCENT_BTN,
+                                        color="primary",
+                                        outline=False,
+                                        size="sm",
+                                    ),
+                                    width="auto",
+                                ),
+                            ],
+                            className="g-1",
+                        ),
+                        dbc.Row(
+                            [
+                                dbc.Col("Scale", width="auto"),
+                                dbc.Col(
+                                    dbc.Button(
+                                        "Linear",
+                                        id=app_ids.ResultsIDs.DRAWDOWN_SCALE_LINEAR_BTN,
+                                        color="primary",
+                                        outline=False,
+                                        size="sm",
+                                    ),
+                                    width="auto",
+                                ),
+                                dbc.Col(
+                                    dbc.Button(
+                                        "Log",
+                                        id=app_ids.ResultsIDs.DRAWDOWN_SCALE_LOG_BTN,
+                                        color="primary",
+                                        outline=True,
+                                        size="sm",
+                                    ),
+                                    width="auto",
+                                ),
+                            ],
+                            className="g-1 mt-1",
+                        ),
+                    ]
                 ),
-                type="circle"
-            )
-        ])
-    ], className="mb-1")
+                id=app_ids.ResultsIDs.DRAWDOWN_SETTINGS_POPOVER,
+                target=app_ids.ResultsIDs.DRAWDOWN_SETTINGS_BUTTON,
+                placement="bottom-end",
+                trigger="legacy",
+                autohide=False,
+                is_open=False,
+            ),
+            dbc.CardBody(
+                [
+                    dcc.Loading(
+                        id=app_ids.ResultsIDs.DRAWDOWN_CHART_LOADING,
+                        children=dcc.Graph(
+                            id=app_ids.ResultsIDs.DRAWDOWN_CHART,  # This ID will be targeted by a callback that sets the figure
+                        ),
+                        type="circle",
+                    )
+                ]
+            ),
+            dcc.Store(
+                id=app_ids.ResultsIDs.DRAWDOWN_SETTINGS_STORE,
+                data={"y_axis": "percent", "scale": "linear"},
+            ),
+        ],
+        className="mb-1",
+    )
+
 
 def create_monthly_returns_heatmap() -> dbc.Card:
     """
     Creates the card containing the monthly returns heatmap.
     """
     logger.debug("Creating monthly returns heatmap card structure.")
-    return dbc.Card([
-        dbc.CardHeader(html.H4("Monthly Returns Heatmap", className="card-title mb-0")),
-        dbc.CardBody([
-            dcc.Loading(
-                id=app_ids.ResultsIDs.MONTHLY_RETURNS_HEATMAP_LOADING, # Corrected ID
-                children=dcc.Graph(
-                    id=app_ids.ResultsIDs.MONTHLY_RETURNS_HEATMAP,
-                ),
-                type="circle"
-            )
-        ])
-    ], className="mb-1") # Use mb-1
+    return dbc.Card(
+        [
+            dbc.CardHeader(
+                html.H4("Monthly Returns Heatmap", className="card-title mb-0")
+            ),
+            dbc.CardBody(
+                [
+                    dcc.Loading(
+                        id=app_ids.ResultsIDs.MONTHLY_RETURNS_HEATMAP_LOADING,  # Corrected ID
+                        children=dcc.Graph(
+                            id=app_ids.ResultsIDs.MONTHLY_RETURNS_HEATMAP,
+                        ),
+                        type="circle",
+                    )
+                ]
+            ),
+        ],
+        className="mb-1",
+    )  # Use mb-1
+
 
 def create_trades_table() -> dbc.Card:
     """
@@ -118,63 +284,91 @@ def create_trades_table() -> dbc.Card:
     The table itself will be generated by a callback.
     """
     logger.debug("Creating trades table card structure.")
-    return dbc.Card([
-        dbc.CardHeader(html.H4("Trade History", className="card-title mb-0")),
-        dbc.CardBody([
-            dcc.Loading(
-                id=app_ids.ResultsIDs.TRADES_TABLE_LOADING, # Corrected ID
-                # Container for the DataTable, populated by the callback
-                children=html.Div(id=app_ids.ResultsIDs.TRADES_TABLE_CONTAINER, children=[
-                    # Initial placeholder message
-                    html.Div("Run a backtest to view trade history.")
-                ]),
-                type="circle"
-            )
-        ])
-    ], className="mb-1") # Use mb-1
+    return dbc.Card(
+        [
+            dbc.CardHeader(html.H4("Trade History", className="card-title mb-0")),
+            dbc.CardBody(
+                [
+                    dcc.Loading(
+                        id=app_ids.ResultsIDs.TRADES_TABLE_LOADING,  # Corrected ID
+                        # Container for the DataTable, populated by the callback
+                        children=html.Div(
+                            id=app_ids.ResultsIDs.TRADES_TABLE_CONTAINER,
+                            children=[
+                                # Initial placeholder message
+                                html.Div("Run a backtest to view trade history.")
+                            ],
+                        ),
+                        type="circle",
+                    )
+                ]
+            ),
+        ],
+        className="mb-1",
+    )  # Use mb-1
+
 
 def create_signals_chart() -> dbc.Card:
     """
     Creates the card containing the signals chart and ticker selector.
     """
     logger.debug("Creating signals chart card structure.")
-    return dbc.Card([
-        dbc.CardHeader(
-            dbc.Row([
-                dbc.Col(html.H4("Signals & Price Action", className="card-title mb-0"), width="auto"),
-                dbc.Col(
-                    dbc.Select(
-                        id=app_ids.ResultsIDs.SIGNALS_TICKER_SELECTOR,
-                        options=[],
-                        placeholder="Select Ticker...",
-                        size="sm"
-                    ),
-                    width=4
-                ),
-                dbc.Col(
-                    dbc.Checklist(
-                        id=app_ids.ResultsIDs.SIGNALS_INDICATOR_CHECKLIST,
-                        options=[{"label": "SMA50", "value": "sma50"}, {"label": "SMA200", "value": "sma200"}],
-                        value=[],
-                        inline=True,
-                        switch=True,
-                    ),
-                    width="auto"
+    return dbc.Card(
+        [
+            dbc.CardHeader(
+                dbc.Row(
+                    [
+                        dbc.Col(
+                            html.H4(
+                                "Signals & Price Action", className="card-title mb-0"
+                            ),
+                            width="auto",
+                        ),
+                        dbc.Col(
+                            dbc.Select(
+                                id=app_ids.ResultsIDs.SIGNALS_TICKER_SELECTOR,
+                                options=[],
+                                placeholder="Select Ticker...",
+                                size="sm",
+                            ),
+                            width=4,
+                        ),
+                        dbc.Col(
+                            dbc.Checklist(
+                                id=app_ids.ResultsIDs.SIGNALS_INDICATOR_CHECKLIST,
+                                options=[
+                                    {"label": "SMA50", "value": "sma50"},
+                                    {"label": "SMA200", "value": "sma200"},
+                                ],
+                                value=[],
+                                inline=True,
+                                switch=True,
+                            ),
+                            width="auto",
+                        ),
+                    ],
+                    justify="between",
+                    align="center",
                 )
-            ], justify="between", align="center")
-        ),
-        dbc.CardBody([
-            dcc.Loading(
-                id=app_ids.ResultsIDs.SIGNALS_CHART_LOADING,
-                children=dcc.Graph(
-                    id=app_ids.ResultsIDs.SIGNALS_CHART,
-                ),
-                type="circle"
-            )
-        ])
-    ], className="mb-1") # Use mb-1
+            ),
+            dbc.CardBody(
+                [
+                    dcc.Loading(
+                        id=app_ids.ResultsIDs.SIGNALS_CHART_LOADING,
+                        children=dcc.Graph(
+                            id=app_ids.ResultsIDs.SIGNALS_CHART,
+                        ),
+                        type="circle",
+                    )
+                ]
+            ),
+        ],
+        className="mb-1",
+    )  # Use mb-1
+
 
 # Removed create_status_and_progress_bar - moved to loading_overlay.py
+
 
 # --- NEW: Center Panel Layout ---
 def create_center_panel_layout() -> html.Div:
@@ -183,16 +377,23 @@ def create_center_panel_layout() -> html.Div:
     Arranges components vertically as requested.
     """
     logger.debug("Creating center panel layout.")
-    return html.Div([
-        # New div to wrap actual results
-        html.Div(id=app_ids.ResultsIDs.RESULTS_AREA_WRAPPER, children=[
-            create_portfolio_value_returns_chart(),
-            create_drawdown_chart(),
-            create_monthly_returns_heatmap(),
-            create_signals_chart(),
-            create_trades_table()
-        ], style={'display': 'none'}) # Initially hidden
-    ])
+    return html.Div(
+        [
+            # New div to wrap actual results
+            html.Div(
+                id=app_ids.ResultsIDs.RESULTS_AREA_WRAPPER,
+                children=[
+                    create_portfolio_value_returns_chart(),
+                    create_drawdown_chart(),
+                    create_monthly_returns_heatmap(),
+                    create_signals_chart(),
+                    create_trades_table(),
+                ],
+                style={"display": "none"},
+            )  # Initially hidden
+        ]
+    )
+
 
 # --- NEW: Right Panel Layout ---
 def create_right_panel_layout() -> html.Div:
@@ -201,25 +402,47 @@ def create_right_panel_layout() -> html.Div:
     Uses two cards with specific IDs for callback targeting.
     """
     logger.debug("Creating right panel layout.")
-    return html.Div([
-        dbc.Card([
-            dbc.CardHeader(html.H4("Performance Overview", className="card-title mb-0")),
-            dbc.CardBody(
-                # Container for performance metrics, populated by callback
-                # Use g-2 for smaller gutters between metric cards
-                dbc.Row(id=app_ids.ResultsIDs.PERFORMANCE_METRICS_CONTAINER, className="g-2")
-            )
-        ], className="mb-1", id=app_ids.ResultsIDs.PERFORMANCE_OVERVIEW_CARD, style={'display': 'none'}),
+    return html.Div(
+        [
+            dbc.Card(
+                [
+                    dbc.CardHeader(
+                        html.H4("Performance Overview", className="card-title mb-0")
+                    ),
+                    dbc.CardBody(
+                        # Container for performance metrics, populated by callback
+                        # Use g-2 for smaller gutters between metric cards
+                        dbc.Row(
+                            id=app_ids.ResultsIDs.PERFORMANCE_METRICS_CONTAINER,
+                            className="g-2",
+                        )
+                    ),
+                ],
+                className="mb-1",
+                id=app_ids.ResultsIDs.PERFORMANCE_OVERVIEW_CARD,
+                style={"display": "none"},
+            ),
+            dbc.Card(
+                [
+                    dbc.CardHeader(
+                        html.H4("Trade Statistics", className="card-title mb-0")
+                    ),
+                    dbc.CardBody(
+                        # Container for trade statistics, populated by callback
+                        # Use g-2 for smaller gutters between metric cards
+                        dbc.Row(
+                            id=app_ids.ResultsIDs.TRADE_METRICS_CONTAINER,
+                            className="g-2",
+                        )
+                    ),
+                ],
+                className="mb-1",
+                id=app_ids.ResultsIDs.TRADE_STATISTICS_CARD,
+                style={"display": "none"},
+            ),
+        ]
+    )
 
-        dbc.Card([
-            dbc.CardHeader(html.H4("Trade Statistics", className="card-title mb-0")),
-            dbc.CardBody(
-                # Container for trade statistics, populated by callback
-                # Use g-2 for smaller gutters between metric cards
-                dbc.Row(id=app_ids.ResultsIDs.TRADE_METRICS_CONTAINER, className="g-2")
-            )
-        ], className="mb-1", id=app_ids.ResultsIDs.TRADE_STATISTICS_CARD, style={'display': 'none'})
-    ])
 
 def create_main_results_area() -> html.Div:
     """
@@ -227,21 +450,25 @@ def create_main_results_area() -> html.Div:
     """
     logger.debug("Creating main results display area.")
     return html.Div(
-        id=app_ids.ResultsIDs.RESULTS_AREA_WRAPPER, # Corrected: Access via ResultsIDs class
+        id=app_ids.ResultsIDs.RESULTS_AREA_WRAPPER,  # Corrected: Access via ResultsIDs class
         children=[
-            dbc.Row([
-                dbc.Col(
-                    create_center_panel_layout(), 
-                    id=app_ids.ResultsIDs.CENTER_PANEL_COLUMN, 
-                    width=12, lg=8, 
-                    className="mb-3 mb-lg-0"
-                ),
-                dbc.Col(
-                    create_right_panel_layout(), 
-                    id=app_ids.ResultsIDs.RIGHT_PANEL_COLUMN, 
-                    width=12, lg=4
-                ),
-            ])
+            dbc.Row(
+                [
+                    dbc.Col(
+                        create_center_panel_layout(),
+                        id=app_ids.ResultsIDs.CENTER_PANEL_COLUMN,
+                        width=12,
+                        lg=8,
+                        className="mb-3 mb-lg-0",
+                    ),
+                    dbc.Col(
+                        create_right_panel_layout(),
+                        id=app_ids.ResultsIDs.RIGHT_PANEL_COLUMN,
+                        width=12,
+                        lg=4,
+                    ),
+                ]
+            )
         ],
-        style={"display": "none"}  # Initially hidden, shown after backtest
+        style={"display": "none"},  # Initially hidden, shown after backtest
     )


### PR DESCRIPTION
## Summary
- add IDs for new chart settings menus
- integrate gear button popovers for Portfolio and Drawdown charts
- store settings in `dcc.Store`
- update callbacks to toggle popovers and adjust charts
- refine gear menu styling and persistence

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68414ec0b78c8330a8bc30571fe99783