### PR TITLE
Refine metrics layout

### DIFF
--- a/src/ui/components.py
+++ b/src/ui/components.py
@@ -1,7 +1,7 @@
 import dash_bootstrap_components as dbc
 from dash import html, dcc # Import dcc for potential future components
 import logging
-from typing import Dict, Tuple, Optional, List
+from typing import Dict, Tuple, Optional, List, Any
 
 logger = logging.getLogger(__name__)
 
@@ -104,3 +104,44 @@ def create_metric_card_with_tooltip(title: str,
 # - Function to create a card header section
 # - Custom dropdown component
 # - Icon button component
+
+
+def create_metrics_table(rows: List[Tuple[str, Any, Optional[Any]]]) -> dbc.Table:
+    """Create a simple metrics table.
+
+    Args:
+        rows: List of tuples (label, strategy_value, benchmark_value or None).
+
+    Returns:
+        dbc.Table component representing the metrics.
+    """
+    show_benchmark = any(len(r) > 2 and r[2] is not None for r in rows)
+
+    header_cells = [html.Th("Metric"), html.Th("Strategy")]
+    if show_benchmark:
+        header_cells.append(html.Th("Benchmark"))
+
+    body_rows = []
+    for row in rows:
+        label = row[0]
+        strat_val = row[1]
+        bench_val = row[2] if len(row) > 2 else None
+
+        def _fmt(val):
+            if isinstance(val, (int, float)):
+                return f"{val:.2f}"
+            return "" if val is None else str(val)
+
+        cells = [html.Td(label), html.Td(_fmt(strat_val))]
+        if show_benchmark:
+            cells.append(html.Td(_fmt(bench_val)))
+
+        body_rows.append(html.Tr(cells))
+
+    table = dbc.Table(
+        [html.Thead(html.Tr(header_cells)), html.Tbody(body_rows)],
+        bordered=True,
+        size="sm",
+        className="w-100",
+    )
+    return table


### PR DESCRIPTION
## Summary
- compute benchmark-aware performance stats in service
- add generic metrics table component
- display tables in results callback instead of scattered cards

## Testing
- `python -m py_compile src/services/backtest_service.py src/ui/components.py src/ui/callbacks/backtest_callbacks.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841735e457483309e349c6fdc915f27