### PR TITLE
Improve results visuals and table

### DIFF
--- a/src/services/visualization_service.py
+++ b/src/services/visualization_service.py
@@ -835,28 +835,36 @@ class VisualizationService:
             pivot.values,
             x=month_names,
             y=pivot.index,
-            color_continuous_scale='RdYlGn', # Red-Yellow-Green scale
-            labels={'x':'Month','y':'Year','color':'Return'},
+            color_continuous_scale='RdYlGn',  # Red-Yellow-Green scale
+            labels={'x': 'Month', 'y': 'Year', 'color': 'Return'},
             aspect='auto',
-            title='Monthly Returns Heatmap',
-            text_auto='.2%' # Format text as percentage
+            text_auto='.0%'
         )
         # Update layout for dark theme and better appearance
         fig.update_layout(
-            height=self.height, 
-            template=self.theme, # Use the service's theme (e.g., 'plotly_dark')
-            plot_bgcolor='rgba(0,0,0,0)', # Transparent plot background
-            paper_bgcolor='rgba(0,0,0,0)', # Transparent paper background
-            margin=dict(l=50, r=50, b=50, t=80),
-            xaxis_nticks=12, # Ensure all months are shown
-            yaxis_nticks=len(pivot.index) # Ensure all years are shown
+            height=self.height,
+            template=self.theme,  # Use the service's theme (e.g., 'plotly_dark')
+            plot_bgcolor='rgba(0,0,0,0)',  # Transparent plot background
+            paper_bgcolor='rgba(0,0,0,0)',  # Transparent paper background
+            margin=dict(l=50, r=50, b=50, t=40),
+            xaxis_nticks=12,  # Ensure all months are shown
+            yaxis_nticks=len(pivot.index),  # Ensure all years are shown
+            hovermode="closest",
+            xaxis_showspikes=False,
+            yaxis_showspikes=False,
         )
+        fig.update_layout(title=None)
+        fig.update_yaxes(dtick=1, tickformat="d")
         # Ensure text color contrasts with the heatmap colors
         # Use white text for better contrast on dark theme
         fig.update_layout(
-            font=dict(color='white') # Set default font color for the whole chart
+            font=dict(color='white')
         )
-        fig.update_traces(textfont_color='black') # Keep cell text black for RdYlGn contrast
+        z = pivot.values
+        max_abs = max(abs(z.min()), abs(z.max())) if not np.isnan(z).all() else 1
+        norm = np.abs(z) / max_abs
+        text_colors = np.where(norm < 0.4, '#f0f0f0', '#111111')
+        fig.update_traces(textfont_color=text_colors)
         return fig
 
     def prepare_trades_for_table(self, trades):

--- a/src/ui/callbacks/backtest_callbacks.py
+++ b/src/ui/callbacks/backtest_callbacks.py
@@ -23,7 +23,8 @@ from dash import (
 import plotly.graph_objects as go
 import plotly.io as pio
 import dash_bootstrap_components as dbc  # Import dbc
-from dash import dash_table  # Import dash_table
+from dash import dash_table
+from dash.dash_table.Format import Format, Scheme, Group
 
 # Import services and components
 from src.services.backtest_service import BacktestService
@@ -570,11 +571,23 @@ def register_backtest_callbacks(app: Dash):
 
         # Create trades table only if we have valid trades data
         if has_trades:
-            # Check if trade data contains the expected columns
             if trades_list and isinstance(trades_list[0], dict) and trades_list[0]:
+                columns = [
+                    {"name": "Entry Date", "id": "entry_date"},
+                    {"name": "Exit Date", "id": "exit_date"},
+                    {"name": "Ticker", "id": "ticker"},
+                    {"name": "Direction", "id": "direction"},
+                    {"name": "Entry Price", "id": "entry_price", "type": "numeric", "format": Format(precision=2, scheme=Scheme.fixed)},
+                    {"name": "Exit Price", "id": "exit_price", "type": "numeric", "format": Format(precision=2, scheme=Scheme.fixed)},
+                    {"name": "Size", "id": "size", "type": "numeric"},
+                    {"name": "PnL", "id": "pnl", "type": "numeric", "format": Format(precision=0, scheme=Scheme.fixed, group=Group.yes)},
+                    {"name": "Return %", "id": "return_pct", "type": "numeric", "format": Format(precision=0, scheme=Scheme.fixed, group=Group.yes).symbol_suffix('%')},
+                    {"name": "Duration", "id": "duration"},
+                    {"name": "Exit Reason", "id": "exit_reason"},
+                ]
                 trades_table_component = dash_table.DataTable(
                     data=trades_list,
-                    columns=[{"name": i, "id": i} for i in trades_list[0].keys()],
+                    columns=columns,
                     style_as_list_view=True,
                     style_header={
                         "backgroundColor": "rgb(30, 30, 30)",
@@ -586,7 +599,15 @@ def register_backtest_callbacks(app: Dash):
                         "color": "white",
                         "textAlign": "left",
                         "padding": "5px",
+                        "fontFamily": "inherit",
+                        "fontSize": "14px",
                     },
+                    style_data_conditional=[
+                        {"if": {"filter_query": "{pnl} > 0", "column_id": "pnl"}, "color": "#28a745"},
+                        {"if": {"filter_query": "{pnl} < 0", "column_id": "pnl"}, "color": "#dc3545"},
+                        {"if": {"filter_query": "{return_pct} > 0", "column_id": "return_pct"}, "color": "#28a745"},
+                        {"if": {"filter_query": "{return_pct} < 0", "column_id": "return_pct"}, "color": "#dc3545"},
+                    ],
                     page_size=10,
                 )
             else:
@@ -843,15 +864,35 @@ def register_backtest_callbacks(app: Dash):
     @app.callback(
         Output(ResultsIDs.SIGNALS_CHART, "figure"),
         Input(ResultsIDs.SIGNALS_TICKER_SELECTOR, "value"),
-        Input(ResultsIDs.SIGNALS_INDICATOR_CHECKLIST, "value"),
+        State(ResultsIDs.BACKTEST_RESULTS_STORE, "data"),
         prevent_initial_call=True,
     )
-    def update_signals_chart(ticker, indicators):
-        """Update signals chart for selected ticker with optional indicators."""
-        if not ticker:
+    def update_signals_chart(ticker, results_data):
+        """Update signals chart for selected ticker using strategy defaults."""
+        if not ticker or not results_data:
             raise PreventUpdate
 
-        fig = backtest_service.get_signals_chart(ticker, indicators or [])
+        strategy = (results_data.get("strategy_type") or "").upper()
+        indicators = []
+        if strategy == "MAC":
+            indicators = ["sma50", "sma200"]
+        elif strategy == "BB":
+            indicators = ["bollinger"]
+        elif strategy == "RSI":
+            indicators = ["rsi"]
+
+        signals_df = None
+        signals_dict = results_data.get("signals", {})
+        if isinstance(signals_dict, dict) and ticker in signals_dict:
+            try:
+                signals_df = pd.read_json(signals_dict[ticker], orient="split")
+            except ValueError:
+                try:
+                    signals_df = pd.read_json(signals_dict[ticker])
+                except Exception:
+                    signals_df = None
+
+        fig = backtest_service.get_signals_chart(ticker, indicators, signals_df)
         if fig is None:
             return create_empty_chart("No signal data")
         return fig

--- a/src/ui/layouts/results_display.py
+++ b/src/ui/layouts/results_display.py
@@ -329,20 +329,7 @@ def create_signals_chart() -> dbc.Card:
                                 placeholder="Select Ticker...",
                                 size="sm",
                             ),
-                            width=4,
-                        ),
-                        dbc.Col(
-                            dbc.Checklist(
-                                id=app_ids.ResultsIDs.SIGNALS_INDICATOR_CHECKLIST,
-                                options=[
-                                    {"label": "SMA50", "value": "sma50"},
-                                    {"label": "SMA200", "value": "sma200"},
-                                ],
-                                value=[],
-                                inline=True,
-                                switch=True,
-                            ),
-                            width="auto",
+                            width=3,
                         ),
                     ],
                     justify="between",

--- a/src/visualization/visualizer.py
+++ b/src/visualization/visualizer.py
@@ -404,28 +404,49 @@ class BacktestVisualizer:
             max_abs = max(abs(pivot_df.min().min()), abs(pivot_df.max().max()))
             
             # Create heatmap
-            fig = go.Figure(data=go.Heatmap(
-                z=pivot_df.values,
-                x=pivot_df.columns,
-                y=pivot_df.index,
-                colorscale=colorscale,
-                zmin=-max_abs,
-                zmax=max_abs,
-                hoverongaps=False,
-                colorbar=dict(
-                    title="Return (%)",
-                    ticksuffix="%"
-                ),
-                hovertemplate="Year: %{y}<br>Month: %{x}<br>Return: %{z:.2f}%<extra></extra>"
-            ))
-            
-            # Update layout
-            layout = _create_base_layout(
-                title="Monthly Returns",
-                height=400,
-                margin=dict(t=50, l=40, r=80, b=40)
+            text_vals = pivot_df.round(0).fillna(0).astype(int).values
+            norm = np.abs(pivot_df.values) / max_abs
+            text_colors = np.where(norm < 0.4, "#f0f0f0", "#111111")
+
+            fig = go.Figure(
+                data=go.Heatmap(
+                    z=pivot_df.values,
+                    x=pivot_df.columns,
+                    y=pivot_df.index,
+                    colorscale=colorscale,
+                    zmin=-max_abs,
+                    zmax=max_abs,
+                    hoverongaps=False,
+                    colorbar=dict(title="Return (%)", ticksuffix="%"),
+                    hovertemplate="Year: %{y}<br>Month: %{x}<br>Return: %{z:.2f}%<extra></extra>",
+                )
             )
-            fig.update_layout(layout)
+
+            for i, year in enumerate(pivot_df.index):
+                fig.add_trace(
+                    go.Scatter(
+                        x=pivot_df.columns,
+                        y=[year] * len(pivot_df.columns),
+                        mode="text",
+                        text=text_vals[i],
+                        textfont=dict(color=text_colors[i]),
+                        showlegend=False,
+                        hoverinfo="skip",
+                    )
+                )
+
+            layout = _create_base_layout(
+                title="",
+                height=400,
+                margin=dict(t=40, l=40, r=80, b=40),
+            )
+            fig.update_layout(
+                layout,
+                hovermode="closest",
+                xaxis_showspikes=False,
+                yaxis_showspikes=False,
+            )
+            fig.update_yaxes(dtick=1, tickformat="d")
             return fig
             
         except Exception as e:


### PR DESCRIPTION
## Summary
- add strategy type to results payload
- improve monthly returns heatmap formatting
- slim ticker selector and auto-show MAs in signals chart
- compute cleaner trades table
- fix data table formatting bug

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6841801ed0e48330bdff96f61706b34e